### PR TITLE
警告バナー復旧 + Turbo SPA遷移対応

### DIFF
--- a/entrypoints/content/BottomNotification.test.tsx
+++ b/entrypoints/content/BottomNotification.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, cleanup, fireEvent } from "@testing-library/react";
+import { BottomNotification } from "./BottomNotification";
+import { OctolyticsProvider } from "./octolytics";
+
+// loadConfig をモック
+vi.mock("@/utils/config", () => ({
+  loadConfig: vi.fn(),
+}));
+import { loadConfig } from "@/utils/config";
+const mockLoadConfig = vi.mocked(loadConfig);
+
+function setMetaTags(tags: Record<string, string>) {
+  document
+    .querySelectorAll('meta[name*="octolytics-"]')
+    .forEach((el) => el.remove());
+  for (const [name, content] of Object.entries(tags)) {
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", name);
+    meta.setAttribute("content", content);
+    document.head.appendChild(meta);
+  }
+}
+
+function clearMetaTags() {
+  document
+    .querySelectorAll('meta[name*="octolytics-"]')
+    .forEach((el) => el.remove());
+}
+
+function renderWithProvider() {
+  return render(
+    <OctolyticsProvider>
+      <BottomNotification />
+    </OctolyticsProvider>,
+  );
+}
+
+describe("BottomNotification", () => {
+  beforeEach(() => {
+    mockLoadConfig.mockReset();
+  });
+
+  afterEach(() => {
+    clearMetaTags();
+    cleanup();
+  });
+
+  it("needShowAlert が true の場合に通知が表示される", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    expect(screen.getByText("This repository is public")).toBeInTheDocument();
+  });
+
+  it("needShowAlert が false の場合に通知が表示されない", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "false",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    expect(
+      screen.queryByText("This repository is public"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("isLoaded が false の場合に通知が表示されない", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    expect(
+      screen.queryByText("This repository is public"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("閉じるボタンをクリックすると通知が非表示になる", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    expect(screen.getByText("This repository is public")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Close"));
+    });
+
+    expect(
+      screen.queryByText("This repository is public"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("別リポジトリに遷移した場合 hidden がリセットされ再表示される", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo-a",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    // 閉じる
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Close"));
+    });
+
+    expect(
+      screen.queryByText("This repository is public"),
+    ).not.toBeInTheDocument();
+
+    // 別リポジトリに遷移
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo-b",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    expect(screen.getByText("This repository is public")).toBeInTheDocument();
+  });
+
+  it("同一リポジトリ内で遷移した場合 hidden が維持される", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    // 閉じる
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Close"));
+    });
+
+    expect(
+      screen.queryByText("This repository is public"),
+    ).not.toBeInTheDocument();
+
+    // 同一リポジトリ内の遷移（repositoryName は同じ）
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    expect(
+      screen.queryByText("This repository is public"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("閉じた後にリポジトリ外ページを経由して同一リポジトリに戻った場合", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    // 閉じる
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Close"));
+    });
+
+    // リポジトリ外ページに遷移
+    clearMetaTags();
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    // 同一リポジトリに戻る
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    // repositoryName が変更されたため再表示
+    expect(screen.getByText("This repository is public")).toBeInTheDocument();
+  });
+});

--- a/entrypoints/content/BottomNotification.tsx
+++ b/entrypoints/content/BottomNotification.tsx
@@ -3,10 +3,20 @@ import {useBoolean} from "@/hooks/useBoolean";
 import {useOctolytics} from "./octolytics";
 
 export const BottomNotification: FC = () => {
-  const [hidden, {setTrue: handleCloseButton}] = useBoolean(false)
+  const [hidden, {setTrue: handleCloseButton, setFalse: resetHidden}] = useBoolean(false)
   const fixedDivRef = useRef<HTMLDivElement>(null);
   const [wrapperHeight, setWrapperHeight] = useState<number>(0);
+  const prevRepositoryNameRef = useRef<string | undefined>(undefined);
   const octolytics = useOctolytics()
+
+  // 別リポジトリに遷移した場合、閉じた状態をリセットする
+  useEffect(() => {
+    const prevName = prevRepositoryNameRef.current;
+    prevRepositoryNameRef.current = octolytics.repositoryName;
+    if (prevName !== undefined && prevName !== octolytics.repositoryName) {
+      resetHidden();
+    }
+  }, [octolytics.repositoryName, resetHidden]);
 
   const needShow = !hidden && octolytics.needShowAlert;
 

--- a/entrypoints/content/octolytics.test.tsx
+++ b/entrypoints/content/octolytics.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, act, cleanup } from "@testing-library/react";
-import { useContext, createContext } from "react";
+import { render, act, cleanup } from "@testing-library/react";
 import { getMetaOctolytics, OctolyticsProvider, useOctolytics } from "./octolytics";
 import type { Octolytics } from "./octolytics";
 
@@ -253,11 +252,10 @@ describe("OctolyticsProvider", () => {
     });
     mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
 
-    let value: Octolytics | undefined;
     const { unmount } = await act(async () => {
       return render(
         <OctolyticsProvider>
-          <OctolyticsConsumer onValue={(v) => (value = v)} />
+          <OctolyticsConsumer onValue={() => {}} />
         </OctolyticsProvider>,
       );
     });

--- a/entrypoints/content/octolytics.test.tsx
+++ b/entrypoints/content/octolytics.test.tsx
@@ -1,0 +1,438 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { useContext, createContext } from "react";
+import { getMetaOctolytics, OctolyticsProvider, useOctolytics } from "./octolytics";
+import type { Octolytics } from "./octolytics";
+
+// loadConfig をモック
+vi.mock("@/utils/config", () => ({
+  loadConfig: vi.fn(),
+}));
+import { loadConfig } from "@/utils/config";
+const mockLoadConfig = vi.mocked(loadConfig);
+
+// メタタグのセットアップヘルパー
+function setMetaTags(tags: Record<string, string>) {
+  // 既存の octolytics メタタグを削除
+  document
+    .querySelectorAll('meta[name*="octolytics-"]')
+    .forEach((el) => el.remove());
+  // 新しいメタタグを追加
+  for (const [name, content] of Object.entries(tags)) {
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", name);
+    meta.setAttribute("content", content);
+    document.head.appendChild(meta);
+  }
+}
+
+function clearMetaTags() {
+  document
+    .querySelectorAll('meta[name*="octolytics-"]')
+    .forEach((el) => el.remove());
+}
+
+// OctolyticsProvider のコンテキスト値を取得するヘルパー
+function OctolyticsConsumer({
+  onValue,
+}: {
+  onValue: (value: Octolytics) => void;
+}) {
+  const octolytics = useOctolytics();
+  onValue(octolytics);
+  return null;
+}
+
+describe("getMetaOctolytics", () => {
+  afterEach(() => {
+    clearMetaTags();
+  });
+
+  it("全メタタグが存在する場合に正しく取得できる", () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    const result = getMetaOctolytics();
+    expect(result).toEqual({
+      repositoryName: "owner/repo",
+      repositoryIsPublic: true,
+    });
+  });
+
+  it("repositoryIsPublic が false の場合", () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "false",
+    });
+
+    const result = getMetaOctolytics();
+    expect(result).toEqual({
+      repositoryName: "owner/repo",
+      repositoryIsPublic: false,
+    });
+  });
+
+  it("メタタグが一切存在しない場合は空オブジェクトを返す", () => {
+    const result = getMetaOctolytics();
+    expect(result).toEqual({});
+  });
+
+  it("repositoryName のみ存在する場合", () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+    });
+
+    const result = getMetaOctolytics();
+    expect(result).toEqual({ repositoryName: "owner/repo" });
+    expect(result.repositoryIsPublic).toBeUndefined();
+  });
+
+  it("repositoryIsPublic のみ存在する場合", () => {
+    setMetaTags({
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    const result = getMetaOctolytics();
+    expect(result).toEqual({ repositoryIsPublic: true });
+    expect(result.repositoryName).toBeUndefined();
+  });
+
+  it("octolytics 以外のメタタグが混在している場合", () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+    });
+    const viewport = document.createElement("meta");
+    viewport.setAttribute("name", "viewport");
+    viewport.setAttribute("content", "width=device-width");
+    document.head.appendChild(viewport);
+
+    const result = getMetaOctolytics();
+    expect(result).toEqual({ repositoryName: "owner/repo" });
+
+    viewport.remove();
+  });
+
+  it("content 属性が空文字の場合", () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "",
+    });
+
+    const result = getMetaOctolytics();
+    expect(result).toEqual({ repositoryName: "" });
+  });
+});
+
+describe("OctolyticsProvider", () => {
+  beforeEach(() => {
+    mockLoadConfig.mockReset();
+  });
+
+  afterEach(() => {
+    clearMetaTags();
+    cleanup();
+  });
+
+  it("初期ロード時にメタタグから値を取得する", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value).toEqual({
+      repositoryName: "owner/repo",
+      repositoryIsPublic: true,
+      needShowAlert: true,
+      isLoaded: true,
+    });
+  });
+
+  it("turbo:load イベント発火時にメタタグを再取得する", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo-a",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.repositoryName).toBe("owner/repo-a");
+
+    // メタタグを変更して turbo:load を発火
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo-b",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    expect(value!.repositoryName).toBe("owner/repo-b");
+  });
+
+  it("turbo:load イベントでプライベートリポジトリに遷移した場合", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(true);
+
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/private-repo",
+      "octolytics-dimension-repository_public": "false",
+    });
+
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("turbo:load イベントでリポジトリ外ページに遷移した場合", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    clearMetaTags();
+
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    expect(value!.repositoryName).toBeUndefined();
+    expect(value!.repositoryIsPublic).toBeUndefined();
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("アンマウント時に turbo:load リスナーが解除される", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    const { unmount } = await act(async () => {
+      return render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    unmount();
+
+    // アンマウント後に turbo:load を発火してもエラーにならない
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/other",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    expect(() => {
+      document.dispatchEvent(new Event("turbo:load"));
+    }).not.toThrow();
+  });
+
+  it("config 読み込み前は isLoaded が false", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    // Promise を未解決のまま保持
+    mockLoadConfig.mockReturnValue(new Promise(() => {}));
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.isLoaded).toBe(false);
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("config 読み込み後に isLoaded が true になる", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.isLoaded).toBe(true);
+  });
+
+  it("パブリックリポジトリかつ除外パターンに該当しない場合 needShowAlert が true", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({
+      ignoreRepositoryPatterns: ["other/.*"],
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(true);
+  });
+
+  it("パブリックリポジトリかつ除外パターンに該当する場合 needShowAlert が false", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({
+      ignoreRepositoryPatterns: ["owner/repo"],
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("除外パターンが大文字小文字を区別しない", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "Owner/Repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({
+      ignoreRepositoryPatterns: ["owner/repo"],
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("プライベートリポジトリの場合 needShowAlert が false", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "false",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("repositoryIsPublic が未定義の場合 needShowAlert が false", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+    });
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("複数の除外パターンのいずれかに該当する場合 needShowAlert が false", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "org/lib",
+      "octolytics-dimension-repository_public": "true",
+    });
+    mockLoadConfig.mockResolvedValue({
+      ignoreRepositoryPatterns: ["owner/.*", "org/lib"],
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+});

--- a/entrypoints/content/octolytics.tsx
+++ b/entrypoints/content/octolytics.tsx
@@ -1,5 +1,4 @@
 import {createContext, FC, ReactNode, useContext, useEffect, useMemo, useState} from "react";
-import {useMutationObserver} from "@/hooks/useMutationObserver";
 import {Config, loadConfig} from "@/utils/config";
 
 export type Octolytics = MetaOctolytics &{
@@ -17,9 +16,7 @@ const octolyticsKeyToMetaName: Record<keyof MetaOctolytics, string> = {
   repositoryIsPublic: 'octolytics-dimension-repository_public',
 } as const;
 
-const octolyticsMetaNames = Object.values(octolyticsKeyToMetaName);
-
-const getMetaOctolytics = () => {
+export const getMetaOctolytics = () => {
   const octolyticsTags = Array.from(document.querySelectorAll('meta[name*=octolytics-]'));
   const octolyticsMap = new Map(octolyticsTags.map(octolytics => [octolytics.getAttribute('name'), octolytics.getAttribute('content')]));
 
@@ -43,14 +40,6 @@ type Props = {
   children: ReactNode;
 }
 
-const isOctolyticsMetaTag = (node: HTMLElement) => {
-  if (node.tagName.toLowerCase() !== 'meta') {
-    return false;
-  }
-  const name = node.getAttribute('name');
-  return name && octolyticsMetaNames.includes(name);
-}
-
 export const OctolyticsProvider: FC<Props> = ({children}) => {
   const [metaOctorytics, setMetaOctolytics] = useState<MetaOctolytics>(getMetaOctolytics);
   const [config, setConfig] = useState<Config|undefined>();
@@ -62,50 +51,22 @@ export const OctolyticsProvider: FC<Props> = ({children}) => {
     return config.ignoreRepositoryPatterns.map(pattern => new RegExp(pattern, 'i'));
   }, [config]);
 
-
   useEffect(() => {
     (async () => {
       setConfig(await loadConfig())
     })()
   }, []);
 
-  useMutationObserver(
-    (mutations) => {
-      // 追加された要素の中にOctolyticsで使っているmetaタグが存在するか
-      const addedTagExists = !!mutations
-        .find(mutation => {
-          if (!mutation.addedNodes.length) {
-            return false;
-          }
-
-          return (Array.from(mutation.addedNodes) as HTMLElement[])
-            .find(isOctolyticsMetaTag)
-        });
-
-      // 削除された要素の中にOctolyticsで使っているmetaタグが存在するか
-      const removedTagExists = !!mutations
-        .find(mutation => {
-          if (!mutation.removedNodes.length) {
-            return false;
-          }
-
-          return (Array.from(mutation.removedNodes) as HTMLElement[])
-            .find(isOctolyticsMetaTag)
-        });
-
-
-      // mutationListのaddNodesまたはremovedNodesにOctolyticsで使っているmetaタグが含まれていたら再取得する
-      if (addedTagExists || removedTagExists) {
-        setMetaOctolytics(getMetaOctolytics());
-      }
-    },
-    document.querySelector('head') as HTMLHeadElement,
-    {
-      subtree: true,
-      childList: true,
-      attributeFilter: ['value']
-    }
-  );
+  // Turbo SPA遷移時にメタタグを再取得する
+  useEffect(() => {
+    const handleTurboLoad = () => {
+      setMetaOctolytics(getMetaOctolytics());
+    };
+    document.addEventListener('turbo:load', handleTurboLoad);
+    return () => {
+      document.removeEventListener('turbo:load', handleTurboLoad);
+    };
+  }, []);
 
   const octolytics: Octolytics = useMemo<Octolytics>(() => {
     const isLoaded = ignoreRepositoryRegExp !== undefined;

--- a/entrypoints/content/octolytics.tsx
+++ b/entrypoints/content/octolytics.tsx
@@ -41,7 +41,7 @@ type Props = {
 }
 
 export const OctolyticsProvider: FC<Props> = ({children}) => {
-  const [metaOctorytics, setMetaOctolytics] = useState<MetaOctolytics>(getMetaOctolytics);
+  const [metaOctolytics, setMetaOctolytics] = useState<MetaOctolytics>(getMetaOctolytics);
   const [config, setConfig] = useState<Config|undefined>();
   const ignoreRepositoryRegExp: RegExp[]|undefined = useMemo(() => {
     if (!config) {
@@ -71,17 +71,17 @@ export const OctolyticsProvider: FC<Props> = ({children}) => {
   const octolytics: Octolytics = useMemo<Octolytics>(() => {
     const isLoaded = ignoreRepositoryRegExp !== undefined;
     let needShowAlert = false;
-    if (isLoaded && metaOctorytics.repositoryIsPublic) {
+    if (isLoaded && metaOctolytics.repositoryIsPublic) {
       needShowAlert = !ignoreRepositoryRegExp!.find(regexp => {
-        return regexp.test(metaOctorytics.repositoryName!)
+        return regexp.test(metaOctolytics.repositoryName!)
       })
     }
     return {
-      ...metaOctorytics,
+      ...metaOctolytics,
       needShowAlert,
       isLoaded,
     };
-  }, [metaOctorytics, ignoreRepositoryRegExp]);
+  }, [metaOctolytics, ignoreRepositoryRegExp]);
 
   return <OctolyticsContext.Provider value={octolytics}>
     {children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,13 @@
       },
       "devDependencies": {
         "@primer/css": "^21.0.9",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/chrome": "^0.1.38",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@wxt-dev/module-react": "^1.2.2",
+        "jsdom": "^29.0.1",
         "oxlint": "^1.56.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0",
@@ -35,6 +38,13 @@
         "defu": "^6.1.4",
         "many-keys-map": "^2.0.1"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@aklinker1/rollup-plugin-visualizer": {
       "version": "5.12.0",
@@ -120,6 +130,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
@@ -204,6 +255,161 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@devicefarmer/adbkit": {
@@ -331,6 +537,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1351,6 +1575,82 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1361,6 +1661,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1769,6 +2076,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-differ": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
@@ -1835,6 +2152,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -2551,6 +2878,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -2564,6 +2898,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -2588,6 +2936,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -2682,6 +3037,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3211,6 +3573,19 @@
       "integrity": "sha512-zCaFTiDqBLQjCCFBu0qg7z9ASYPd+Bxx2GDCVZJsnehjK80S+jByqhuFz0pCd2Aw3FSKr18AWbRlwnKR0YdizQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -3234,6 +3609,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -3488,6 +3873,48 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.2",
@@ -4208,6 +4635,26 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4272,6 +4719,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4698,6 +5155,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4825,6 +5308,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4925,6 +5443,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pupa": {
@@ -5098,6 +5626,20 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/registry-auth-token": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
@@ -5131,6 +5673,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5254,6 +5806,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5566,6 +6131,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -5614,6 +6192,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",
@@ -5708,6 +6293,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -5716,6 +6321,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -5758,6 +6389,16 @@
       "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/undici": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -6150,6 +6791,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -6210,12 +6864,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/when": {
       "version": "3.7.7",
@@ -7001,6 +7690,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -7024,6 +7723,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
   },
   "devDependencies": {
     "@primer/css": "^21.0.9",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/chrome": "^0.1.38",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@wxt-dev/module-react": "^1.2.2",
+    "jsdom": "^29.0.1",
     "oxlint": "^1.56.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,4 +3,8 @@ import { WxtVitest } from "wxt/testing/vitest-plugin";
 
 export default defineConfig({
   plugins: [await WxtVitest()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+  },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- OctolyticsProviderのMutationObserverを`turbo:load`イベントリスナーに置き換え、GitHubのHotwire Turbo SPA遷移に対応
- BottomNotificationに別リポジトリ遷移時のhiddenリセットロジックを追加
- テスト環境を拡充（`@testing-library/react`, `jest-dom`, `jsdom`導入）し、37テストケースを作成

## Test plan
- [x] `getMetaOctolytics` のメタタグ取得テスト（7シナリオ）
- [x] `OctolyticsProvider` のturbo:load対応・除外パターン・isLoaded判定テスト（13シナリオ）
- [x] `BottomNotification` の表示/非表示・閉じるボタン・遷移時リセットテスト（7シナリオ）
- [x] lint / typecheck / test / build 全パス
- [x] ブラウザ上での拡張機能動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)