### PR TITLE
フォームインターセプト復旧 + DOM対応

### DIFF
--- a/entrypoints/content/PublicRepositoryFormObserver.test.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+import { PublicRepositoryFormObserver } from "./PublicRepositoryFormObserver";
+
+// useOctolytics をモック
+const mockUseOctolytics = vi.fn();
+vi.mock("./octolytics", () => ({
+  useOctolytics: () => mockUseOctolytics(),
+}));
+
+function createComposer(): HTMLElement {
+  const composer = document.createElement("div");
+  composer.setAttribute("data-testid", "comment-composer");
+  document.body.appendChild(composer);
+  return composer;
+}
+
+describe("PublicRepositoryFormObserver", () => {
+  beforeEach(() => {
+    mockUseOctolytics.mockReset();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("needShowAlertがfalseの場合は何もレンダリングしない", () => {
+    const composer = createComposer();
+    mockUseOctolytics.mockReturnValue({ needShowAlert: false, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    expect(composer.style.display).not.toBe("none");
+  });
+
+  it("isLoadedがfalseの場合は何もレンダリングしない", () => {
+    const composer = createComposer();
+    mockUseOctolytics.mockReturnValue({ needShowAlert: false, isLoaded: false });
+
+    render(<PublicRepositoryFormObserver />);
+
+    expect(composer.style.display).not.toBe("none");
+  });
+
+  it("初期レンダリング時に既存のコンポーザーをインターセプトする", () => {
+    const composer = createComposer();
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    expect(composer.style.display).toBe("none");
+    expect(composer.previousElementSibling).not.toBeNull();
+    expect(
+      composer.previousElementSibling!.querySelector("strong")?.textContent,
+    ).toBe("Are you sure you want to join in public discussion?");
+  });
+
+  it("初期レンダリング時に複数のコンポーザーを全てインターセプトする", () => {
+    const composerA = createComposer();
+    const composerB = createComposer();
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    expect(composerA.style.display).toBe("none");
+    expect(composerB.style.display).toBe("none");
+  });
+
+  it("動的に追加されたコンポーザーをMutationObserverで検出してインターセプトする", async () => {
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    const composer = createComposer();
+
+    // MutationObserverのコールバックは非同期でマイクロタスクとして実行されるため、
+    // 複数回のflushが必要な場合がある
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(composer.style.display).toBe("none");
+      });
+    });
+  });
+
+  it("動的追加されたノードの子孫にあるコンポーザーも検出する", async () => {
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    const parent = document.createElement("div");
+    const composer = document.createElement("div");
+    composer.setAttribute("data-testid", "comment-composer");
+    parent.appendChild(composer);
+    document.body.appendChild(parent);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(composer.style.display).toBe("none");
+  });
+
+  it("HTMLElement以外のノード追加は無視する", async () => {
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    // テキストノードを追加
+    const textNode = document.createTextNode("test");
+    document.body.appendChild(textNode);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // エラーが発生しないことを確認（テストが正常に完了すればOK）
+    expect(true).toBe(true);
+  });
+
+  it("SPA遷移（turbo:load）後に新ページのコンポーザーをインターセプトする", async () => {
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    // SPA遷移をシミュレート: 新しいコンポーザーを追加してからturbo:loadを発火
+    const composer = createComposer();
+    // data-attributeをクリア（新しいページのDOM）
+    await act(async () => {
+      document.dispatchEvent(new Event("turbo:load"));
+    });
+
+    expect(composer.style.display).toBe("none");
+  });
+
+  it("コンポーザーが存在しないページでもエラーにならない", () => {
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    expect(() => {
+      render(<PublicRepositoryFormObserver />);
+    }).not.toThrow();
+  });
+
+  it("旧セレクタ（form.js-new-comment-form等）に一致する要素はインターセプトしない", () => {
+    const form = document.createElement("form");
+    form.classList.add("js-new-comment-form");
+    document.body.appendChild(form);
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    expect(form.style.display).not.toBe("none");
+  });
+
+  it("needShowAlertがtrueからfalseに変わった場合にインターセプトを停止する", () => {
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+    const { rerender } = render(<PublicRepositoryFormObserver />);
+
+    // needShowAlertがfalseに変わる
+    mockUseOctolytics.mockReturnValue({ needShowAlert: false, isLoaded: true });
+    rerender(<PublicRepositoryFormObserver />);
+
+    // 新しく追加されたコンポーザーはインターセプトされない
+    const newComposer = createComposer();
+    expect(newComposer.style.display).not.toBe("none");
+  });
+
+  it("needShowAlertがfalseからtrueに変わった場合にインターセプトを開始する", () => {
+    const composer = createComposer();
+    mockUseOctolytics.mockReturnValue({ needShowAlert: false, isLoaded: true });
+    const { rerender } = render(<PublicRepositoryFormObserver />);
+
+    expect(composer.style.display).not.toBe("none");
+
+    // needShowAlertがtrueに変わる
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+    rerender(<PublicRepositoryFormObserver />);
+
+    expect(composer.style.display).toBe("none");
+  });
+});

--- a/entrypoints/content/PublicRepositoryFormObserver.test.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.test.tsx
@@ -123,9 +123,8 @@ describe("PublicRepositoryFormObserver", () => {
 
     render(<PublicRepositoryFormObserver />);
 
-    // SPA遷移をシミュレート: 新しいコンポーザーを追加してからturbo:loadを発火
+    // SPA遷移をシミュレート: 新しいコンポーザーを追加してからturbo:loadを発火し、新しいページのDOM読み込みを再現
     const composer = createComposer();
-    // data-attributeをクリア（新しいページのDOM）
     await act(async () => {
       document.dispatchEvent(new Event("turbo:load"));
     });

--- a/entrypoints/content/PublicRepositoryFormObserver.test.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.test.tsx
@@ -36,7 +36,7 @@ describe("PublicRepositoryFormObserver", () => {
 
   it("isLoadedがfalseの場合は何もレンダリングしない", () => {
     const composer = createComposer();
-    mockUseOctolytics.mockReturnValue({ needShowAlert: false, isLoaded: false });
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: false });
 
     render(<PublicRepositoryFormObserver />);
 

--- a/entrypoints/content/PublicRepositoryFormObserver.test.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.test.tsx
@@ -141,9 +141,31 @@ describe("PublicRepositoryFormObserver", () => {
     }).not.toThrow();
   });
 
-  it("旧セレクタ（form.js-new-comment-form等）に一致する要素はインターセプトしない", () => {
+  it("PRコメントフォーム（form.js-new-comment-form）をインターセプトする", () => {
     const form = document.createElement("form");
     form.classList.add("js-new-comment-form");
+    document.body.appendChild(form);
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    expect(form.style.display).toBe("none");
+  });
+
+  it("レビューコメント返信フォーム（form.js-inline-comment-form）をインターセプトする", () => {
+    const form = document.createElement("form");
+    form.classList.add("js-inline-comment-form");
+    document.body.appendChild(form);
+    mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
+
+    render(<PublicRepositoryFormObserver />);
+
+    expect(form.style.display).toBe("none");
+  });
+
+  it("対象外のセレクタ（form.new_issue等）はインターセプトしない", () => {
+    const form = document.createElement("form");
+    form.classList.add("new_issue");
     document.body.appendChild(form);
     mockUseOctolytics.mockReturnValue({ needShowAlert: true, isLoaded: true });
 

--- a/entrypoints/content/PublicRepositoryFormObserver.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.tsx
@@ -3,7 +3,11 @@ import {useMutationObserver} from "@/hooks/useMutationObserver";
 import {useOctolytics} from "./octolytics";
 import {confirmJoinDiscussion} from "./public-repository-form-action/confirmJoinDiscussion";
 
-const OBSERVE_COMPOSER_SELECTOR = '[data-testid="comment-composer"]';
+const OBSERVE_COMPOSER_SELECTOR = [
+  '[data-testid="comment-composer"]',
+  'form.js-new-comment-form',
+  'form.js-inline-comment-form',
+].join(',');
 
 export const PublicRepositoryFormObserver: React.FC = () => {
   const {needShowAlert, isLoaded} = useOctolytics();

--- a/entrypoints/content/PublicRepositoryFormObserver.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.tsx
@@ -1,9 +1,9 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useLayoutEffect} from "react";
 import {useMutationObserver} from "@/hooks/useMutationObserver";
 import {useOctolytics} from "./octolytics";
 import {confirmJoinDiscussion} from "./public-repository-form-action/confirmJoinDiscussion";
 
-const OBSERVE_COMPOSER_SELECTOR = [
+const OBSERVE_TARGET_SELECTOR = [
   '[data-testid="comment-composer"]',
   'form.js-new-comment-form',
   'form.js-inline-comment-form',
@@ -19,12 +19,14 @@ export const PublicRepositoryFormObserver: React.FC = () => {
 };
 
 const scanAndIntercept = () => {
-  document.querySelectorAll<HTMLElement>(OBSERVE_COMPOSER_SELECTOR).forEach(eachComposerAction);
+  document.querySelectorAll<HTMLElement>(OBSERVE_TARGET_SELECTOR).forEach(eachComposerAction);
 };
 
 const WatchingForm: React.FC = () => {
-  // 読み込み時に既に存在しているコンポーザーに対して実行
-  scanAndIntercept();
+  // 読み込み時に既に存在しているコンポーザーに対して実行（ちらつき防止のためuseLayoutEffect）
+  useLayoutEffect(() => {
+    scanAndIntercept();
+  }, []);
 
   // turbo:load（SPA遷移）時にコンポーザーを再スキャン
   useEffect(() => {
@@ -50,10 +52,10 @@ const WatchingForm: React.FC = () => {
 
               // 追加されたノード自体がコンポーザーの場合と、子孫にコンポーザーがある場合の両方を検出
               const composers: HTMLElement[] = [];
-              if (node.matches(OBSERVE_COMPOSER_SELECTOR)) {
+              if (node.matches(OBSERVE_TARGET_SELECTOR)) {
                 composers.push(node);
               }
-              composers.push(...Array.from(node.querySelectorAll<HTMLElement>(OBSERVE_COMPOSER_SELECTOR)));
+              composers.push(...Array.from(node.querySelectorAll<HTMLElement>(OBSERVE_TARGET_SELECTOR)));
               return composers;
             }).flat()
         })

--- a/entrypoints/content/PublicRepositoryFormObserver.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.tsx
@@ -1,15 +1,9 @@
-import React from "react";
+import React, {useEffect} from "react";
 import {useMutationObserver} from "@/hooks/useMutationObserver";
 import {useOctolytics} from "./octolytics";
 import {confirmJoinDiscussion} from "./public-repository-form-action/confirmJoinDiscussion";
 
-// 以下のフォームに対して実行する
-const OBSERVE_FORM_SELECTOR = [
-  'form.js-new-comment-form',
-  'form.new_issue',
-  'form.new-pr-form',
-  'form.js-inline-comment-form',
-].join(',');
+const OBSERVE_COMPOSER_SELECTOR = '[data-testid="comment-composer"]';
 
 export const PublicRepositoryFormObserver: React.FC = () => {
   const {needShowAlert, isLoaded} = useOctolytics();
@@ -20,11 +14,26 @@ export const PublicRepositoryFormObserver: React.FC = () => {
   return <WatchingForm />;
 };
 
-const WatchingForm: React.FC = () => {
-  // 読み込み時に既に存在しているフォームに対して実行
-  document.querySelectorAll<HTMLFormElement>(OBSERVE_FORM_SELECTOR).forEach(eachFormAction);
+const scanAndIntercept = () => {
+  document.querySelectorAll<HTMLElement>(OBSERVE_COMPOSER_SELECTOR).forEach(eachComposerAction);
+};
 
-  // 追加されたフォームに対して実行
+const WatchingForm: React.FC = () => {
+  // 読み込み時に既に存在しているコンポーザーに対して実行
+  scanAndIntercept();
+
+  // turbo:load（SPA遷移）時にコンポーザーを再スキャン
+  useEffect(() => {
+    const handleTurboLoad = () => {
+      scanAndIntercept();
+    };
+    document.addEventListener('turbo:load', handleTurboLoad);
+    return () => {
+      document.removeEventListener('turbo:load', handleTurboLoad);
+    };
+  }, []);
+
+  // 動的に追加されたコンポーザーに対して実行
   useMutationObserver(
     (mutations) => {
       mutations
@@ -35,11 +44,17 @@ const WatchingForm: React.FC = () => {
                 return [];
               }
 
-              return Array.from(node.querySelectorAll<HTMLFormElement>(OBSERVE_FORM_SELECTOR))
+              // 追加されたノード自体がコンポーザーの場合と、子孫にコンポーザーがある場合の両方を検出
+              const composers: HTMLElement[] = [];
+              if (node.matches(OBSERVE_COMPOSER_SELECTOR)) {
+                composers.push(node);
+              }
+              composers.push(...Array.from(node.querySelectorAll<HTMLElement>(OBSERVE_COMPOSER_SELECTOR)));
+              return composers;
             }).flat()
         })
         .flat()
-        .forEach(eachFormAction);
+        .forEach(eachComposerAction);
     },
     document.querySelector('body') as HTMLBodyElement,
     {
@@ -51,6 +66,6 @@ const WatchingForm: React.FC = () => {
   return null;
 };
 
-const eachFormAction = (form: HTMLFormElement) => {
-  confirmJoinDiscussion(form);
+const eachComposerAction = (composer: HTMLElement) => {
+  confirmJoinDiscussion(composer);
 };

--- a/entrypoints/content/PublicRepositoryFormObserver.tsx
+++ b/entrypoints/content/PublicRepositoryFormObserver.tsx
@@ -62,7 +62,7 @@ const WatchingForm: React.FC = () => {
         .flat()
         .forEach(eachComposerAction);
     },
-    document.querySelector('body') as HTMLBodyElement,
+    document.body,
     {
       subtree: true,
       childList: true,

--- a/entrypoints/content/public-repository-form-action/confirmJoinDiscussion.test.ts
+++ b/entrypoints/content/public-repository-form-action/confirmJoinDiscussion.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { confirmJoinDiscussion } from "./confirmJoinDiscussion";
+
+function createComposer(): HTMLElement {
+  const composer = document.createElement("div");
+  composer.setAttribute("data-testid", "comment-composer");
+  document.body.appendChild(composer);
+  return composer;
+}
+
+describe("confirmJoinDiscussion", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("コンポーザー要素を非表示にして警告バナーを表示する", () => {
+    const composer = createComposer();
+
+    confirmJoinDiscussion(composer);
+
+    expect(composer.style.display).toBe("none");
+    const banner = composer.previousElementSibling as HTMLElement;
+    expect(banner).not.toBeNull();
+    expect(banner.querySelector("strong")?.textContent).toBe(
+      "Are you sure you want to join in public discussion?",
+    );
+    expect(banner.querySelector("button")?.textContent).toBe("Got it.");
+  });
+
+  it("警告バナーのボタンをクリックするとフォームが復元される", () => {
+    const composer = createComposer();
+    confirmJoinDiscussion(composer);
+
+    const banner = composer.previousElementSibling as HTMLElement;
+    const button = banner.querySelector("button") as HTMLButtonElement;
+    button.click();
+
+    expect(composer.style.display).toBe("");
+    expect(banner.parentElement).toBeNull();
+  });
+
+  it("同一要素に対して二重実行されない", () => {
+    const composer = createComposer();
+
+    confirmJoinDiscussion(composer);
+    confirmJoinDiscussion(composer);
+
+    const banners = document.querySelectorAll(".flash");
+    expect(banners.length).toBe(1);
+  });
+
+  it("複数のコンポーザー要素に対してそれぞれ独立に動作する", () => {
+    const composerA = createComposer();
+    const composerB = createComposer();
+
+    confirmJoinDiscussion(composerA);
+    confirmJoinDiscussion(composerB);
+
+    expect(composerA.style.display).toBe("none");
+    expect(composerB.style.display).toBe("none");
+
+    const bannerA = composerA.previousElementSibling as HTMLElement;
+    bannerA.querySelector("button")!.click();
+
+    expect(composerA.style.display).toBe("");
+    expect(composerB.style.display).toBe("none");
+    // composerBの警告バナーはまだ存在する
+    expect(composerB.previousElementSibling).not.toBeNull();
+  });
+
+  it("HTMLElement（非form要素）を受け取れる", () => {
+    const composer = document.createElement("div");
+    composer.setAttribute("data-testid", "comment-composer");
+    document.body.appendChild(composer);
+
+    confirmJoinDiscussion(composer);
+
+    expect(composer.style.display).toBe("none");
+    expect(composer.previousElementSibling).not.toBeNull();
+  });
+});

--- a/entrypoints/content/public-repository-form-action/confirmJoinDiscussion.ts
+++ b/entrypoints/content/public-repository-form-action/confirmJoinDiscussion.ts
@@ -1,13 +1,13 @@
 const CONFIRM_JOIN_DISCUSSION_DATA_ATTRIBUTE = 'publicRepoAlertConfirmJoinDiscussionFeature';
-export const confirmJoinDiscussion = (form: HTMLFormElement) => {
-  // formごとに1回のみ実行する
-  if (form.dataset[CONFIRM_JOIN_DISCUSSION_DATA_ATTRIBUTE] === 'true') {
+export const confirmJoinDiscussion = (composer: HTMLElement) => {
+  // コンポーザーごとに1回のみ実行する
+  if (composer.dataset[CONFIRM_JOIN_DISCUSSION_DATA_ATTRIBUTE] === 'true') {
     return;
   }
-  form.dataset[CONFIRM_JOIN_DISCUSSION_DATA_ATTRIBUTE] = 'true';
+  composer.dataset[CONFIRM_JOIN_DISCUSSION_DATA_ATTRIBUTE] = 'true';
 
-  // コメントフォームを非表示にする
-  form.style.display = 'none';
+  // コンポーザーを非表示にする
+  composer.style.display = 'none';
 
   // 警告文を表示する
   const wrapper = document.createElement('div');
@@ -19,11 +19,11 @@ export const confirmJoinDiscussion = (form: HTMLFormElement) => {
     <button type="button" class="btn">Got it.</button>
   </div>
   `;
-  form.before(wrapper);
+  composer.before(wrapper);
 
-  // 警告文のボタンを押したらコメントフォームを表示する
+  // 警告文のボタンを押したらコンポーザーを表示する
   wrapper.querySelector('button')?.addEventListener('click', () => {
-    form.style.display = '';
+    composer.style.display = '';
     wrapper.remove();
   });
 }


### PR DESCRIPTION
## Summary
- GitHubのフォーム実装がページタイプにより異なる（Issue: React / PR・レビュー: 旧来form）ため、新旧セレクタを併用
- `confirmJoinDiscussion`の引数型を`HTMLFormElement`→`HTMLElement`に変更し、コンポーザー要素全体の非表示に対応
- `PublicRepositoryFormObserver`に`turbo:load`イベントリスナーを追加し、SPA遷移時のフォーム再スキャンに対応
- MutationObserverで追加ノード自体が対象セレクタにマッチするケースも検出するよう修正

### 対応するフォーム
- Issueコメント: `[data-testid="comment-composer"]`
- PRコメント: `form.js-new-comment-form`
- レビューコメント返信: `form.js-inline-comment-form`

### 対応しないフォーム
- Issue作成フォーム
- PR作成フォーム

## Test plan
- [x] lint / typecheck / test / build 全てパス
- [x] Chromeでパブリックリポジトリの**Issueコメント**フォームがインターセプトされることを確認
- [x] Chromeでパブリックリポジトリの**PRコメント**フォームがインターセプトされることを確認
- [x] Chromeでパブリックリポジトリの**レビューコメント返信**フォームがインターセプトされることを確認
- [x] 「Got it.」ボタンクリックでフォームが復元されることを確認
- [x] 除外パターンに一致するリポジトリではインターセプトされないことを確認
- [x] SPA遷移後もフォームがインターセプトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)