### PR TITLE
設定画面のテスト追加 + @primer/css削除

### DIFF
--- a/entrypoints/options/App.test.tsx
+++ b/entrypoints/options/App.test.tsx
@@ -30,11 +30,9 @@ describe("App", () => {
   it("設定読み込み完了後にSettingが表示される", async () => {
     mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
 
-    await act(async () => {
-      render(<App />);
-    });
+    render(<App />);
 
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(await screen.findByRole("textbox")).toBeInTheDocument();
   });
 
   it("保存済みの除外パターンがtextareaに表示される", async () => {
@@ -42,11 +40,9 @@ describe("App", () => {
       ignoreRepositoryPatterns: ["owner/repo", "^org/"],
     });
 
-    await act(async () => {
-      render(<App />);
-    });
+    render(<App />);
 
-    const textarea = screen.getByRole("textbox");
+    const textarea = await screen.findByRole("textbox");
     expect(textarea).toHaveValue("owner/repo\n^org/");
   });
 });

--- a/entrypoints/options/App.test.tsx
+++ b/entrypoints/options/App.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { App } from "./App";
+
+vi.mock("@/utils/config", () => ({
+  loadConfig: vi.fn(),
+}));
+import { loadConfig } from "@/utils/config";
+const mockLoadConfig = vi.mocked(loadConfig);
+
+describe("App", () => {
+  beforeEach(() => {
+    mockLoadConfig.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("設定読み込み完了前はSettingが表示されない", async () => {
+    mockLoadConfig.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("設定読み込み完了後にSettingが表示される", async () => {
+    mockLoadConfig.mockResolvedValue({ ignoreRepositoryPatterns: [] });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("保存済みの除外パターンがtextareaに表示される", async () => {
+    mockLoadConfig.mockResolvedValue({
+      ignoreRepositoryPatterns: ["owner/repo", "^org/"],
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveValue("owner/repo\n^org/");
+  });
+});

--- a/entrypoints/options/Setting.test.tsx
+++ b/entrypoints/options/Setting.test.tsx
@@ -28,7 +28,7 @@ describe("Setting", () => {
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
+    vi.clearAllTimers();
     vi.useRealTimers();
     cleanup();
   });

--- a/entrypoints/options/Setting.test.tsx
+++ b/entrypoints/options/Setting.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { ThemeProvider, BaseStyles } from "@primer/react";
+import { Setting } from "./Setting";
+import type { Config } from "@/utils/config";
+
+vi.mock("@/utils/config", () => ({
+  saveConfig: vi.fn(),
+}));
+import { saveConfig } from "@/utils/config";
+const mockSaveConfig = vi.mocked(saveConfig);
+
+function renderSetting(config: Config) {
+  return render(
+    <ThemeProvider>
+      <BaseStyles>
+        <Setting config={config} />
+      </BaseStyles>
+    </ThemeProvider>,
+  );
+}
+
+describe("Setting", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSaveConfig.mockReset();
+    mockSaveConfig.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  describe("初期表示", () => {
+    it("除外パターンが改行区切りでtextareaに表示される", () => {
+      renderSetting({ ignoreRepositoryPatterns: ["repo-a", "repo-b"] });
+
+      const textarea = screen.getByRole("textbox");
+      expect(textarea).toHaveValue("repo-a\nrepo-b");
+    });
+
+    it("除外パターンが空配列の場合はtextareaが空", () => {
+      renderSetting({ ignoreRepositoryPatterns: [] });
+
+      const textarea = screen.getByRole("textbox");
+      expect(textarea).toHaveValue("");
+    });
+
+    it("placeholderが正しく設定される", () => {
+      renderSetting({ ignoreRepositoryPatterns: [] });
+
+      const textarea = screen.getByRole("textbox");
+      expect(textarea).toHaveAttribute(
+        "placeholder",
+        "eg. username/repo-name\n^username/",
+      );
+    });
+
+    it("Saveボタンが有効状態で表示される", () => {
+      renderSetting({ ignoreRepositoryPatterns: [] });
+
+      const button = screen.getByRole("button", { name: "Save" });
+      expect(button).toBeEnabled();
+    });
+
+    it("見出しが表示される", () => {
+      renderSetting({ ignoreRepositoryPatterns: [] });
+
+      expect(
+        screen.getByRole("heading", { name: "Public repo Alert Settings" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("フォーム送信", () => {
+    async function submitWithValue(value: string) {
+      renderSetting({ ignoreRepositoryPatterns: [] });
+      const textarea = screen.getByRole("textbox");
+      fireEvent.change(textarea, { target: { value } });
+      await act(async () => {
+        fireEvent.submit(screen.getByRole("button", { name: "Save" }).closest("form")!);
+      });
+    }
+
+    it("入力値が改行で分割されてsaveConfigに渡される", async () => {
+      await submitWithValue("owner/repo\norg/lib");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: ["owner/repo", "org/lib"],
+      });
+    });
+
+    it("各行がtrimされる", async () => {
+      await submitWithValue("  owner/repo  \n  org/lib  ");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: ["owner/repo", "org/lib"],
+      });
+    });
+
+    it("空行が除去される", async () => {
+      await submitWithValue("owner/repo\n\n\norg/lib\n");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: ["owner/repo", "org/lib"],
+      });
+    });
+
+    it("CRLFの改行コードで正しく分割される", async () => {
+      await submitWithValue("owner/repo\r\norg/lib");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: ["owner/repo", "org/lib"],
+      });
+    });
+
+    it("CRの改行コードで正しく分割される", async () => {
+      await submitWithValue("owner/repo\rorg/lib");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: ["owner/repo", "org/lib"],
+      });
+    });
+
+    it("textareaが空の場合は空配列で保存される", async () => {
+      await submitWithValue("");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: [],
+      });
+    });
+
+    it("空白のみの行しかない場合は空配列で保存される", async () => {
+      await submitWithValue("   \n   \n   ");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: [],
+      });
+    });
+
+    it("パターンが1つだけの場合", async () => {
+      await submitWithValue("owner/repo");
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        ignoreRepositoryPatterns: ["owner/repo"],
+      });
+    });
+  });
+
+  describe("Savedボタン", () => {
+    async function submitForm() {
+      renderSetting({ ignoreRepositoryPatterns: [] });
+      const textarea = screen.getByRole("textbox");
+      fireEvent.change(textarea, { target: { value: "owner/repo" } });
+      await act(async () => {
+        fireEvent.submit(screen.getByRole("button", { name: "Save" }).closest("form")!);
+      });
+    }
+
+    it("フォーム送信後にSavedボタンに切り替わる", async () => {
+      await submitForm();
+
+      const savedButton = screen.getByRole("button", { name: "Saved" });
+      expect(savedButton).toBeDisabled();
+    });
+
+    it("Savedボタンが3秒後にSaveボタンに戻る", async () => {
+      await submitForm();
+
+      expect(screen.getByRole("button", { name: "Saved" })).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      const saveButton = screen.getByRole("button", { name: "Save" });
+      expect(saveButton).toBeEnabled();
+    });
+
+    it("Savedボタンが3秒未満ではSaveに戻らない", async () => {
+      await submitForm();
+
+      await act(async () => {
+        vi.advanceTimersByTime(2999);
+      });
+
+      expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+    });
+  });
+});

--- a/entrypoints/options/Setting.test.tsx
+++ b/entrypoints/options/Setting.test.tsx
@@ -28,6 +28,7 @@ describe("Setting", () => {
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
     vi.useRealTimers();
     cleanup();
   });

--- a/entrypoints/options/integration.test.tsx
+++ b/entrypoints/options/integration.test.tsx
@@ -45,6 +45,7 @@ async function renderAndWaitForLoad(onValue: (value: Octolytics) => void) {
     );
   });
   await waitFor(() => {
+    expect(value).toBeDefined();
     expect(value!.isLoaded).toBe(true);
   });
 }

--- a/entrypoints/options/integration.test.tsx
+++ b/entrypoints/options/integration.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+import { fakeBrowser } from "wxt/testing";
+import { saveConfig } from "@/utils/config";
+import { OctolyticsProvider, useOctolytics } from "@/entrypoints/content/octolytics";
+import type { Octolytics } from "@/entrypoints/content/octolytics";
+
+// loadConfig をモックしない — 実際の chrome.storage.local（fakeBrowser）を経由する
+
+function setMetaTags(tags: Record<string, string>) {
+  document
+    .querySelectorAll('meta[name*="octolytics-"]')
+    .forEach((el) => el.remove());
+  for (const [name, content] of Object.entries(tags)) {
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", name);
+    meta.setAttribute("content", content);
+    document.head.appendChild(meta);
+  }
+}
+
+function clearMetaTags() {
+  document
+    .querySelectorAll('meta[name*="octolytics-"]')
+    .forEach((el) => el.remove());
+}
+
+function OctolyticsConsumer({
+  onValue,
+}: {
+  onValue: (value: Octolytics) => void;
+}) {
+  const octolytics = useOctolytics();
+  onValue(octolytics);
+  return null;
+}
+
+describe("統合テスト: 設定画面 → content script 反映", () => {
+  afterEach(() => {
+    clearMetaTags();
+    cleanup();
+    fakeBrowser.reset();
+  });
+
+  it("設定画面で保存した除外パターンがOctolyticsProviderで反映される", async () => {
+    // 設定画面で保存（fakeBrowser 経由で chrome.storage.local に書き込み）
+    await saveConfig({ ignoreRepositoryPatterns: ["owner/repo"] });
+
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("設定画面で除外パターンを空にした場合はアラートが表示される", async () => {
+    await saveConfig({ ignoreRepositoryPatterns: [] });
+
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(true);
+  });
+
+  it("設定画面で保存した正規表現パターンがOctolyticsProviderで正しく評価される", async () => {
+    await saveConfig({ ignoreRepositoryPatterns: ["^owner/"] });
+
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/any-repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(false);
+  });
+
+  it("設定画面で保存したパターンに該当しないリポジトリではアラートが表示される", async () => {
+    await saveConfig({ ignoreRepositoryPatterns: ["owner/repo"] });
+
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "other/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+
+    let value: Octolytics | undefined;
+    await act(async () => {
+      render(
+        <OctolyticsProvider>
+          <OctolyticsConsumer onValue={(v) => (value = v)} />
+        </OctolyticsProvider>,
+      );
+    });
+
+    expect(value!.needShowAlert).toBe(true);
+  });
+});

--- a/entrypoints/options/integration.test.tsx
+++ b/entrypoints/options/integration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { render, act, cleanup } from "@testing-library/react";
+import { render, act, cleanup, waitFor } from "@testing-library/react";
 import { fakeBrowser } from "wxt/testing";
 import { saveConfig } from "@/utils/config";
 import { OctolyticsProvider, useOctolytics } from "@/entrypoints/content/octolytics";
@@ -35,6 +35,20 @@ function OctolyticsConsumer({
   return null;
 }
 
+async function renderAndWaitForLoad(onValue: (value: Octolytics) => void) {
+  let value: Octolytics | undefined;
+  await act(async () => {
+    render(
+      <OctolyticsProvider>
+        <OctolyticsConsumer onValue={(v) => { value = v; onValue(v); }} />
+      </OctolyticsProvider>,
+    );
+  });
+  await waitFor(() => {
+    expect(value!.isLoaded).toBe(true);
+  });
+}
+
 describe("統合テスト: 設定画面 → content script 反映", () => {
   afterEach(() => {
     clearMetaTags();
@@ -43,7 +57,6 @@ describe("統合テスト: 設定画面 → content script 反映", () => {
   });
 
   it("設定画面で保存した除外パターンがOctolyticsProviderで反映される", async () => {
-    // 設定画面で保存（fakeBrowser 経由で chrome.storage.local に書き込み）
     await saveConfig({ ignoreRepositoryPatterns: ["owner/repo"] });
 
     setMetaTags({
@@ -51,16 +64,11 @@ describe("統合テスト: 設定画面 → content script 反映", () => {
       "octolytics-dimension-repository_public": "true",
     });
 
-    let value: Octolytics | undefined;
-    await act(async () => {
-      render(
-        <OctolyticsProvider>
-          <OctolyticsConsumer onValue={(v) => (value = v)} />
-        </OctolyticsProvider>,
-      );
-    });
+    let result: Octolytics | undefined;
+    await renderAndWaitForLoad((v) => { result = v; });
 
-    expect(value!.needShowAlert).toBe(false);
+    expect(result!.isLoaded).toBe(true);
+    expect(result!.needShowAlert).toBe(false);
   });
 
   it("設定画面で除外パターンを空にした場合はアラートが表示される", async () => {
@@ -71,16 +79,11 @@ describe("統合テスト: 設定画面 → content script 反映", () => {
       "octolytics-dimension-repository_public": "true",
     });
 
-    let value: Octolytics | undefined;
-    await act(async () => {
-      render(
-        <OctolyticsProvider>
-          <OctolyticsConsumer onValue={(v) => (value = v)} />
-        </OctolyticsProvider>,
-      );
-    });
+    let result: Octolytics | undefined;
+    await renderAndWaitForLoad((v) => { result = v; });
 
-    expect(value!.needShowAlert).toBe(true);
+    expect(result!.isLoaded).toBe(true);
+    expect(result!.needShowAlert).toBe(true);
   });
 
   it("設定画面で保存した正規表現パターンがOctolyticsProviderで正しく評価される", async () => {
@@ -91,16 +94,11 @@ describe("統合テスト: 設定画面 → content script 反映", () => {
       "octolytics-dimension-repository_public": "true",
     });
 
-    let value: Octolytics | undefined;
-    await act(async () => {
-      render(
-        <OctolyticsProvider>
-          <OctolyticsConsumer onValue={(v) => (value = v)} />
-        </OctolyticsProvider>,
-      );
-    });
+    let result: Octolytics | undefined;
+    await renderAndWaitForLoad((v) => { result = v; });
 
-    expect(value!.needShowAlert).toBe(false);
+    expect(result!.isLoaded).toBe(true);
+    expect(result!.needShowAlert).toBe(false);
   });
 
   it("設定画面で保存したパターンに該当しないリポジトリではアラートが表示される", async () => {
@@ -111,15 +109,10 @@ describe("統合テスト: 設定画面 → content script 反映", () => {
       "octolytics-dimension-repository_public": "true",
     });
 
-    let value: Octolytics | undefined;
-    await act(async () => {
-      render(
-        <OctolyticsProvider>
-          <OctolyticsConsumer onValue={(v) => (value = v)} />
-        </OctolyticsProvider>,
-      );
-    });
+    let result: Octolytics | undefined;
+    await renderAndWaitForLoad((v) => { result = v; });
 
-    expect(value!.needShowAlert).toBe(true);
+    expect(result!.isLoaded).toBe(true);
+    expect(result!.needShowAlert).toBe(true);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "react-dom": "^19.2.4"
       },
       "devDependencies": {
-        "@primer/css": "^21.0.9",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/chrome": "^0.1.38",
@@ -582,60 +581,6 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
-    "node_modules/@github/auto-check-element": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@github/auto-check-element/-/auto-check-element-5.4.1.tgz",
-      "integrity": "sha512-AJeHV1ifpby5Hp2wJIzcsdIB5YAq869F7ilNv2GygTVpHOSCfYSS29/hJ5GGTLgfKpPRgTmJcMi5OetKR8eH1g==",
-      "dev": true,
-      "dependencies": {
-        "@github/mini-throttle": "^2.1.0"
-      }
-    },
-    "node_modules/@github/auto-complete-element": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@github/auto-complete-element/-/auto-complete-element-3.6.0.tgz",
-      "integrity": "sha512-u8fG8nCosSFv2wlKMsGga+FaFu/jkexZVFIDxLiCyLVTB8zRRu/RJyufzNnmbOZHYBezCMNBgJ0quuEBoyRh9Q==",
-      "dev": true,
-      "dependencies": {
-        "@github/combobox-nav": "^2.1.7"
-      }
-    },
-    "node_modules/@github/catalyst": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.6.0.tgz",
-      "integrity": "sha512-u8A+DameixqpeyHzvnJWTGj+wfiskQOYHzSiJscCWVfMkIT3rxnbHMtGh3lMthaRY21nbUOK71WcsCnCrXhBJQ==",
-      "dev": true
-    },
-    "node_modules/@github/clipboard-copy-element": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@github/clipboard-copy-element/-/clipboard-copy-element-1.3.0.tgz",
-      "integrity": "sha512-wyntkQkwoLbLo+Hqg2LIVMXDIzcvUb9bSDz+clX6nVJItwzh103rHxdXFRZD+DmxVbuEW5xSznYQXkz1jZT+xg==",
-      "dev": true
-    },
-    "node_modules/@github/combobox-nav": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@github/combobox-nav/-/combobox-nav-2.3.1.tgz",
-      "integrity": "sha512-gwxPzLw8XKecy1nP63i9lOBritS3bWmxl02UX6G0TwMQZbMem1BCS1tEZgYd3mkrkiDrUMWaX+DbFCuDFo3K+A==",
-      "dev": true
-    },
-    "node_modules/@github/details-menu-element": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@github/details-menu-element/-/details-menu-element-1.0.13.tgz",
-      "integrity": "sha512-gMkii86w/oUP5dq8yOWZn1sgbgtFj3AYETxxtpsqRggZktgd8te4+npAn4Hm+936c/lxmEzXqfjARL/CzGR4+w==",
-      "dev": true
-    },
-    "node_modules/@github/image-crop-element": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@github/image-crop-element/-/image-crop-element-5.0.0.tgz",
-      "integrity": "sha512-Vgm2OwWAs1ESoib/t5sjxsAYo6YTOxxAjWDRxswX7qrqoyCejTZ3hshdo4Ep5e+Mz/GVTZC3rdMtg06dk/eT4g==",
-      "dev": true
-    },
-    "node_modules/@github/include-fragment-element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@github/include-fragment-element/-/include-fragment-element-6.3.0.tgz",
-      "integrity": "sha512-BJTt8ZE/arsbC9lQtTH8c1hZS0ZigiN+kzH54ffQ6MhHLT83h0OpSdS9NEVocPl2uuO6w3qxnEKTDzUGMQ5rdQ==",
-      "dev": true
-    },
     "node_modules/@github/mini-throttle": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@github/mini-throttle/-/mini-throttle-2.1.1.tgz",
@@ -646,12 +591,6 @@
       "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.5.1.tgz",
       "integrity": "sha512-uxCxCwe9vdwUDmRmM84tN0UERlj8MosLV44+r/VDj7DZUVUSTP4vyWlE9mRK6vHelOmT8DS3RMlaMrLlg1h1PQ==",
       "license": "MIT"
-    },
-    "node_modules/@github/tab-container-element": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@github/tab-container-element/-/tab-container-element-3.3.0.tgz",
-      "integrity": "sha512-vHlN/GXgaJFJhh4oUYRh1pc4RAqduKlQOrEjVgSxR4JhLXsQcZ/hKWfCsRZAuZbSPzUGEYvggdieamS4FRSe4g==",
-      "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -759,12 +698,6 @@
       "engines": {
         "node": "^18 || >=20"
       }
-    },
-    "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.7.tgz",
-      "integrity": "sha512-WNthEIPPXnFQkumLby6yVxhyOcA/GtMnlByHwEglMO9WZckoaqidnpLp2JFzAh2RDOZxn+Xt3ffSMKId9cPjOQ==",
-      "dev": true
     },
     "node_modules/@oxc-project/types": {
       "version": "0.120.0",
@@ -1150,19 +1083,6 @@
       "integrity": "sha512-93juWZbWg2DRhC11+7RT7hMpY1VD3lBosLmccqEZ65yrCHqkBCjI8Uj8wxs3y0U+wWE07LAoLHAPylyWbifg5A==",
       "license": "MIT"
     },
-    "node_modules/@primer/css": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/@primer/css/-/css-21.1.1.tgz",
-      "integrity": "sha512-1XRx8FwWxrr8SSZit2C9KxaofTi0CELKbGmHGpmYQmRIAECIa912Emp4BlAC7iQmf3Tb5oZOkke5zuAt+seDxg==",
-      "dev": true,
-      "dependencies": {
-        "@primer/primitives": "^7.12.0",
-        "@primer/view-components": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@primer/live-region-element": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.7.2.tgz",
@@ -1183,12 +1103,6 @@
       "peerDependencies": {
         "react": ">=16.3"
       }
-    },
-    "node_modules/@primer/primitives": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.15.3.tgz",
-      "integrity": "sha512-BFxFKwa0Bkr+esqbXU5Yt91z/58J2MPoW1cYtp0j2rUYus4lIZnczX7+ZYb7j4BqpfY/88q9Vn+BRwW/Sx4eIA==",
-      "dev": true
     },
     "node_modules/@primer/react": {
       "version": "38.16.0",
@@ -1259,25 +1173,6 @@
       "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.5.1.tgz",
       "integrity": "sha512-NB9uYfJ01FVY6zp+33EoUbJ0paS3JrWY+PqdHPebTvyRtQgL3sX8//3jWqjt3/jL81UMEulJRM2A0hPj0/vFpQ==",
       "license": "MIT"
-    },
-    "node_modules/@primer/view-components": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@primer/view-components/-/view-components-0.14.0.tgz",
-      "integrity": "sha512-q5kctH/ujpVYYljZGWjmwZXU7s1VT70TEE6+JeIAgtohkIIMFKdlHsrzmrQ+4AwDW01Pi3maHLiIcDy3HTe1JA==",
-      "dev": true,
-      "dependencies": {
-        "@github/auto-check-element": "^5.2.0",
-        "@github/auto-complete-element": "^3.3.4",
-        "@github/catalyst": "^1.6.0",
-        "@github/clipboard-copy-element": "^1.3.0",
-        "@github/details-menu-element": "^1.0.12",
-        "@github/image-crop-element": "^5.0.0",
-        "@github/include-fragment-element": "^6.1.1",
-        "@github/relative-time-element": "^4.0.0",
-        "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.3.2",
-        "@primer/behaviors": "^1.3.4"
-      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@primer/css": "^21.0.9",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/chrome": "^0.1.38",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,10 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
+    server: {
+      deps: {
+        inline: ["@primer/react"],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Options page（App.tsx, Setting.tsx）のユニットテストを追加（19テスト）
- 設定保存→content script反映の統合テストを追加（4テスト）
- 不要な`@primer/css`をdevDependenciesから削除
- `vitest.config.ts`に`@primer/react`のCSS inlineを設定追加

## Test plan
- [x] App.tsx: 設定読み込み前後の表示制御、保存済みパターンの表示（3テスト）
- [x] Setting.tsx: 初期表示、フォーム送信（改行分割・trim・空行除去・CRLF/CR対応）、Savedボタン状態遷移（16テスト）
- [x] 統合テスト: 設定画面で保存した除外パターンがOctolyticsProviderに反映される確認（4テスト）
- [x] 全テスト79件パス、lint/typecheck/buildエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)