### PR TITLE
オプションページ全面改修（Build 02）

### DIFF
--- a/entrypoints/content/octolytics.tsx
+++ b/entrypoints/content/octolytics.tsx
@@ -1,5 +1,5 @@
 import {createContext, FC, ReactNode, useContext, useEffect, useMemo, useState} from "react";
-import {showAlertItem, protectFormItem, ignoreListItem, isIgnored} from "@/utils/storage";
+import {type StorageState, showAlertItem, protectFormItem, ignoreListItem, isIgnored} from "@/utils/storage";
 
 export type Octolytics = MetaOctolytics & {
   showAlert: boolean;
@@ -42,11 +42,6 @@ type Props = {
   children: ReactNode;
 }
 
-type StorageState = {
-  showAlert: boolean;
-  protectForm: boolean;
-  ignoreList: string[];
-} | undefined;
 
 export const OctolyticsProvider: FC<Props> = ({children}) => {
   const [metaOctolytics, setMetaOctolytics] = useState<MetaOctolytics>(getMetaOctolytics);

--- a/entrypoints/options/App.test.tsx
+++ b/entrypoints/options/App.test.tsx
@@ -3,46 +3,101 @@ import { render, screen, act, cleanup } from "@testing-library/react";
 import { App } from "./App";
 
 vi.mock("@/utils/storage", () => ({
+  showAlertItem: {
+    getValue: vi.fn(),
+    setValue: vi.fn().mockResolvedValue(undefined),
+  },
+  protectFormItem: {
+    getValue: vi.fn(),
+    setValue: vi.fn().mockResolvedValue(undefined),
+  },
   ignoreListItem: {
     getValue: vi.fn(),
+    setValue: vi.fn().mockResolvedValue(undefined),
   },
 }));
-import { ignoreListItem } from "@/utils/storage";
-const mockGetValue = vi.mocked(ignoreListItem.getValue);
+import { showAlertItem, protectFormItem, ignoreListItem } from "@/utils/storage";
+const mockShowAlertGetValue = vi.mocked(showAlertItem.getValue);
+const mockProtectFormGetValue = vi.mocked(protectFormItem.getValue);
+const mockIgnoreListGetValue = vi.mocked(ignoreListItem.getValue);
 
 describe("App", () => {
   beforeEach(() => {
-    mockGetValue.mockReset();
+    mockShowAlertGetValue.mockReset();
+    mockProtectFormGetValue.mockReset();
+    mockIgnoreListGetValue.mockReset();
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("設定読み込み完了前はSettingが表示されない", async () => {
-    mockGetValue.mockReturnValue(new Promise(() => {}));
+  it("\u8A2D\u5B9A\u8AAD\u307F\u8FBC\u307F\u5B8C\u4E86\u524D\u306FSetting\u304C\u8868\u793A\u3055\u308C\u306A\u3044", async () => {
+    mockShowAlertGetValue.mockReturnValue(new Promise(() => {}));
+    mockProtectFormGetValue.mockReturnValue(new Promise(() => {}));
+    mockIgnoreListGetValue.mockReturnValue(new Promise(() => {}));
 
     await act(async () => {
       render(<App />);
     });
 
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Public repo Alert Settings" })).not.toBeInTheDocument();
   });
 
-  it("設定読み込み完了後にSettingが表示される", async () => {
-    mockGetValue.mockResolvedValue([]);
+  it("\u8A2D\u5B9A\u8AAD\u307F\u8FBC\u307F\u5B8C\u4E86\u5F8C\u306BSetting\u304C\u8868\u793A\u3055\u308C\u308B", async () => {
+    mockShowAlertGetValue.mockResolvedValue(true);
+    mockProtectFormGetValue.mockResolvedValue(true);
+    mockIgnoreListGetValue.mockResolvedValue([]);
 
     render(<App />);
 
-    expect(await screen.findByRole("textbox")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Public repo Alert Settings" })).toBeInTheDocument();
   });
 
-  it("保存済みの除外リストがtextareaに表示される", async () => {
-    mockGetValue.mockResolvedValue(["owner/repo", "org/*"]);
+  it("showAlert\u304Cfalse\u306E\u5834\u5408\u3001\u30C8\u30B0\u30EB\u304COFF\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", async () => {
+    mockShowAlertGetValue.mockResolvedValue(false);
+    mockProtectFormGetValue.mockResolvedValue(true);
+    mockIgnoreListGetValue.mockResolvedValue([]);
 
     render(<App />);
 
-    const textarea = await screen.findByRole("textbox");
-    expect(textarea).toHaveValue("owner/repo\norg/*");
+    await screen.findByRole("heading", { name: "Public repo Alert Settings" });
+    const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("protectForm\u304Cfalse\u306E\u5834\u5408\u3001\u30C8\u30B0\u30EB\u304COFF\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", async () => {
+    mockShowAlertGetValue.mockResolvedValue(true);
+    mockProtectFormGetValue.mockResolvedValue(false);
+    mockIgnoreListGetValue.mockResolvedValue([]);
+
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "Public repo Alert Settings" });
+    const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("\u4FDD\u5B58\u6E08\u307F\u306E\u9664\u5916\u30EA\u30B9\u30C8\u304C\u4E00\u89A7\u8868\u793A\u3055\u308C\u308B", async () => {
+    mockShowAlertGetValue.mockResolvedValue(true);
+    mockProtectFormGetValue.mockResolvedValue(true);
+    mockIgnoreListGetValue.mockResolvedValue(["owner/repo", "org/*"]);
+
+    render(<App />);
+
+    expect(await screen.findByText("owner/repo")).toBeInTheDocument();
+    expect(screen.getByText("org/*")).toBeInTheDocument();
+  });
+
+  it("\u4E00\u90E8\u306E\u30B9\u30C8\u30EC\u30FC\u30B8\u30A2\u30A4\u30C6\u30E0\u306E\u307F\u89E3\u6C7A\u6E08\u307F\u306E\u5834\u5408\u306FSetting\u304C\u8868\u793A\u3055\u308C\u306A\u3044", async () => {
+    mockShowAlertGetValue.mockResolvedValue(true);
+    mockProtectFormGetValue.mockReturnValue(new Promise(() => {}));
+    mockIgnoreListGetValue.mockResolvedValue([]);
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(screen.queryByRole("heading", { name: "Public repo Alert Settings" })).not.toBeInTheDocument();
   });
 });

--- a/entrypoints/options/App.test.tsx
+++ b/entrypoints/options/App.test.tsx
@@ -62,7 +62,7 @@ describe("App", () => {
     render(<App />);
 
     await screen.findByRole("heading", { name: "Public repo Alert Settings" });
-    const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+    const toggle = screen.getByLabelText("Show Alert");
     expect(toggle).toHaveAttribute("aria-pressed", "false");
   });
 
@@ -74,7 +74,7 @@ describe("App", () => {
     render(<App />);
 
     await screen.findByRole("heading", { name: "Public repo Alert Settings" });
-    const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+    const toggle = screen.getByLabelText("Protect Form");
     expect(toggle).toHaveAttribute("aria-pressed", "false");
   });
 

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,13 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {ThemeProvider, BaseStyles} from '@primer/react'
-import {showAlertItem, protectFormItem, ignoreListItem} from "@/utils/storage";
+import {type StorageState, showAlertItem, protectFormItem, ignoreListItem} from "@/utils/storage";
 import {Setting} from "./Setting";
-
-type StorageState = {
-  showAlert: boolean;
-  protectForm: boolean;
-  ignoreList: string[];
-};
 
 export const App: React.FC = () => {
   const [state, setState] = useState<StorageState | undefined>();

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,20 +1,31 @@
 import React, {useEffect, useState} from "react";
 import {ThemeProvider, BaseStyles} from '@primer/react'
-import {ignoreListItem} from "@/utils/storage";
+import {showAlertItem, protectFormItem, ignoreListItem} from "@/utils/storage";
 import {Setting} from "./Setting";
 
+type StorageState = {
+  showAlert: boolean;
+  protectForm: boolean;
+  ignoreList: string[];
+};
+
 export const App: React.FC = () => {
-  const [ignoreList, setIgnoreList] = useState<string[] | undefined>();
+  const [state, setState] = useState<StorageState | undefined>();
   useEffect(() => {
     (async () => {
-      setIgnoreList(await ignoreListItem.getValue())
+      const [showAlert, protectForm, ignoreList] = await Promise.all([
+        showAlertItem.getValue(),
+        protectFormItem.getValue(),
+        ignoreListItem.getValue(),
+      ]);
+      setState({showAlert, protectForm, ignoreList});
     })()
   }, []);
 
   return (
     <ThemeProvider>
       <BaseStyles>
-        {ignoreList !== undefined ? <Setting ignoreList={ignoreList} /> : null}
+        {state !== undefined ? <Setting {...state} /> : null}
       </BaseStyles>
     </ThemeProvider>
   );

--- a/entrypoints/options/Setting.test.tsx
+++ b/entrypoints/options/Setting.test.tsx
@@ -14,18 +14,12 @@ vi.mock("@/utils/storage", () => ({
     setValue: vi.fn(),
   },
 }));
-import { showAlertItem, protectFormItem, ignoreListItem } from "@/utils/storage";
+import { type StorageState, showAlertItem, protectFormItem, ignoreListItem } from "@/utils/storage";
 const mockShowAlertSetValue = vi.mocked(showAlertItem.setValue);
 const mockProtectFormSetValue = vi.mocked(protectFormItem.setValue);
 const mockIgnoreListSetValue = vi.mocked(ignoreListItem.setValue);
 
-type Props = {
-  showAlert?: boolean;
-  protectForm?: boolean;
-  ignoreList?: string[];
-};
-
-function renderSetting({showAlert = true, protectForm = true, ignoreList = []}: Props = {}) {
+function renderSetting({showAlert = true, protectForm = true, ignoreList = []}: Partial<StorageState> = {}) {
   return render(
     <ThemeProvider>
       <BaseStyles>
@@ -187,22 +181,22 @@ describe("Setting", () => {
     });
   });
 
+  function getInput() {
+    return screen.getByPlaceholderText("owner/repo or owner/*");
+  }
+
+  function getAddButton() {
+    return screen.getByRole("button", { name: "Add New" });
+  }
+
+  async function addPattern(value: string) {
+    fireEvent.change(getInput(), { target: { value } });
+    await act(async () => {
+      fireEvent.click(getAddButton());
+    });
+  }
+
   describe("\u9664\u5916\u30EA\u30B9\u30C8\u8FFD\u52A0", () => {
-    function getInput() {
-      return screen.getByPlaceholderText("owner/repo or owner/*");
-    }
-
-    function getAddButton() {
-      return screen.getByRole("button", { name: "Add New" });
-    }
-
-    async function addPattern(value: string) {
-      fireEvent.change(getInput(), { target: { value } });
-      await act(async () => {
-        fireEvent.click(getAddButton());
-      });
-    }
-
     it("owner/repo\u5F62\u5F0F\u306E\u30D1\u30BF\u30FC\u30F3\u3092\u8FFD\u52A0\u3067\u304D\u308B", async () => {
       renderSetting({ignoreList: ["existing/repo"]});
       await addPattern("new-owner/new-repo");
@@ -229,21 +223,6 @@ describe("Setting", () => {
   });
 
   describe("\u9664\u5916\u30EA\u30B9\u30C8\u8FFD\u52A0 \u30D0\u30EA\u30C7\u30FC\u30B7\u30E7\u30F3", () => {
-    function getInput() {
-      return screen.getByPlaceholderText("owner/repo or owner/*");
-    }
-
-    function getAddButton() {
-      return screen.getByRole("button", { name: "Add New" });
-    }
-
-    async function addPattern(value: string) {
-      fireEvent.change(getInput(), { target: { value } });
-      await act(async () => {
-        fireEvent.click(getAddButton());
-      });
-    }
-
     it("\u7A7A\u6587\u5B57\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
       renderSetting();
       await act(async () => {

--- a/entrypoints/options/Setting.test.tsx
+++ b/entrypoints/options/Setting.test.tsx
@@ -4,174 +4,313 @@ import { ThemeProvider, BaseStyles } from "@primer/react";
 import { Setting } from "./Setting";
 
 vi.mock("@/utils/storage", () => ({
+  showAlertItem: {
+    setValue: vi.fn(),
+  },
+  protectFormItem: {
+    setValue: vi.fn(),
+  },
   ignoreListItem: {
     setValue: vi.fn(),
   },
 }));
-import { ignoreListItem } from "@/utils/storage";
-const mockSetValue = vi.mocked(ignoreListItem.setValue);
+import { showAlertItem, protectFormItem, ignoreListItem } from "@/utils/storage";
+const mockShowAlertSetValue = vi.mocked(showAlertItem.setValue);
+const mockProtectFormSetValue = vi.mocked(protectFormItem.setValue);
+const mockIgnoreListSetValue = vi.mocked(ignoreListItem.setValue);
 
-function renderSetting(ignoreList: string[]) {
+type Props = {
+  showAlert?: boolean;
+  protectForm?: boolean;
+  ignoreList?: string[];
+};
+
+function renderSetting({showAlert = true, protectForm = true, ignoreList = []}: Props = {}) {
   return render(
     <ThemeProvider>
       <BaseStyles>
-        <Setting ignoreList={ignoreList} />
+        <Setting showAlert={showAlert} protectForm={protectForm} ignoreList={ignoreList} />
       </BaseStyles>
     </ThemeProvider>,
   );
 }
 
+const FORMAT_ERROR = "owner/repo \u307E\u305F\u306F owner/* \u306E\u5F62\u5F0F\u3067\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044";
+const DUPLICATE_ERROR = "\u3053\u306E\u30D1\u30BF\u30FC\u30F3\u306F\u65E2\u306B\u767B\u9332\u3055\u308C\u3066\u3044\u307E\u3059";
+
 describe("Setting", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
-    mockSetValue.mockReset();
-    mockSetValue.mockResolvedValue(undefined);
+    mockShowAlertSetValue.mockReset();
+    mockShowAlertSetValue.mockResolvedValue(undefined);
+    mockProtectFormSetValue.mockReset();
+    mockProtectFormSetValue.mockResolvedValue(undefined);
+    mockIgnoreListSetValue.mockReset();
+    mockIgnoreListSetValue.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
-    vi.clearAllTimers();
-    vi.useRealTimers();
     cleanup();
   });
 
-  describe("初期表示", () => {
-    it("除外リストが改行区切りでtextareaに表示される", () => {
-      renderSetting(["repo-a", "repo-b"]);
-
-      const textarea = screen.getByRole("textbox");
-      expect(textarea).toHaveValue("repo-a\nrepo-b");
+  describe("\u521D\u671F\u8868\u793A", () => {
+    it("\u898B\u51FA\u3057\u304C\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting();
+      expect(screen.getByRole("heading", { name: "Public repo Alert Settings" })).toBeInTheDocument();
     });
 
-    it("除外リストが空配列の場合はtextareaが空", () => {
-      renderSetting([]);
-
-      const textarea = screen.getByRole("textbox");
-      expect(textarea).toHaveValue("");
+    it("GitHub\u30EA\u30DD\u30B8\u30C8\u30EA\u3078\u306E\u30EA\u30F3\u30AF\u304C\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting();
+      const link = screen.getByRole("link", { name: "GitHub repository" });
+      expect(link).toHaveAttribute("href", "https://github.com/tak-solder/public-repo-alert");
     });
 
-    it("placeholderが正しく設定される", () => {
-      renderSetting([]);
-
-      const textarea = screen.getByRole("textbox");
-      expect(textarea).toHaveAttribute(
-        "placeholder",
-        "eg. username/repo-name\nusername/*",
-      );
+    it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u30C8\u30B0\u30EB\u304CON\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting({showAlert: true});
+      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+      expect(toggle).toHaveAttribute("aria-pressed", "true");
     });
 
-    it("Saveボタンが有効状態で表示される", () => {
-      renderSetting([]);
-
-      const button = screen.getByRole("button", { name: "Save" });
-      expect(button).toBeEnabled();
+    it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u30C8\u30B0\u30EB\u304COFF\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting({showAlert: false});
+      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+      expect(toggle).toHaveAttribute("aria-pressed", "false");
     });
 
-    it("見出しが表示される", () => {
-      renderSetting([]);
-
-      expect(
-        screen.getByRole("heading", { name: "Public repo Alert Settings" }),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe("フォーム送信", () => {
-    async function submitWithValue(value: string) {
-      renderSetting([]);
-      const textarea = screen.getByRole("textbox");
-      fireEvent.change(textarea, { target: { value } });
-      await act(async () => {
-        fireEvent.submit(screen.getByRole("button", { name: "Save" }).closest("form")!);
-      });
-    }
-
-    it("入力値が改行で分割されてignoreListItemに保存される", async () => {
-      await submitWithValue("owner/repo\norg/lib");
-
-      expect(mockSetValue).toHaveBeenCalledWith(["owner/repo", "org/lib"]);
+    it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u30C8\u30B0\u30EB\u304CON\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting({protectForm: true});
+      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      expect(toggle).toHaveAttribute("aria-pressed", "true");
     });
 
-    it("各行がtrimされる", async () => {
-      await submitWithValue("  owner/repo  \n  org/lib  ");
-
-      expect(mockSetValue).toHaveBeenCalledWith(["owner/repo", "org/lib"]);
+    it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u30C8\u30B0\u30EB\u304COFF\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting({protectForm: false});
+      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      expect(toggle).toHaveAttribute("aria-pressed", "false");
     });
 
-    it("空行が除去される", async () => {
-      await submitWithValue("owner/repo\n\n\norg/lib\n");
-
-      expect(mockSetValue).toHaveBeenCalledWith(["owner/repo", "org/lib"]);
+    it("\u9664\u5916\u30EA\u30B9\u30C8\u304C\u4E00\u89A7\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting({ignoreList: ["owner/repo-a", "org/*"]});
+      expect(screen.getByText("owner/repo-a")).toBeInTheDocument();
+      expect(screen.getByText("org/*")).toBeInTheDocument();
     });
 
-    it("CRLFの改行コードで正しく分割される", async () => {
-      await submitWithValue("owner/repo\r\norg/lib");
-
-      expect(mockSetValue).toHaveBeenCalledWith(["owner/repo", "org/lib"]);
+    it("\u9664\u5916\u30EA\u30B9\u30C8\u304C\u7A7A\u306E\u5834\u5408\u306F\u4E00\u89A7\u304C\u7A7A\u3067\u8868\u793A\u3055\u308C\u308B", () => {
+      renderSetting({ignoreList: []});
+      expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
     });
 
-    it("CRの改行コードで正しく分割される", async () => {
-      await submitWithValue("owner/repo\rorg/lib");
-
-      expect(mockSetValue).toHaveBeenCalledWith(["owner/repo", "org/lib"]);
+    it("\u6B63\u898F\u8868\u73FE\u30D1\u30BF\u30FC\u30F3\u306E\u30C6\u30AD\u30B9\u30C8\u30A8\u30EA\u30A2\u304C\u8868\u793A\u3055\u308C\u306A\u3044", () => {
+      renderSetting();
+      expect(screen.queryByRole("textbox", { name: /ignore/i })).not.toBeInTheDocument();
     });
 
-    it("textareaが空の場合は空配列で保存される", async () => {
-      await submitWithValue("");
-
-      expect(mockSetValue).toHaveBeenCalledWith([]);
-    });
-
-    it("空白のみの行しかない場合は空配列で保存される", async () => {
-      await submitWithValue("   \n   \n   ");
-
-      expect(mockSetValue).toHaveBeenCalledWith([]);
-    });
-
-    it("パターンが1つだけの場合", async () => {
-      await submitWithValue("owner/repo");
-
-      expect(mockSetValue).toHaveBeenCalledWith(["owner/repo"]);
+    it("\u4FDD\u5B58\u30DC\u30BF\u30F3\u304C\u8868\u793A\u3055\u308C\u306A\u3044", () => {
+      renderSetting();
+      expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
     });
   });
 
-  describe("Savedボタン", () => {
-    async function submitForm() {
-      renderSetting([]);
-      const textarea = screen.getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "owner/repo" } });
+  describe("\u30C8\u30B0\u30EB\u64CD\u4F5C", () => {
+    it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u3092ON\u304B\u3089OFF\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
+      renderSetting({showAlert: true});
+      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
       await act(async () => {
-        fireEvent.submit(screen.getByRole("button", { name: "Save" }).closest("form")!);
+        fireEvent.click(toggle);
+      });
+      expect(mockShowAlertSetValue).toHaveBeenCalledWith(false);
+    });
+
+    it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u3092OFF\u304B\u3089ON\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
+      renderSetting({showAlert: false});
+      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+      await act(async () => {
+        fireEvent.click(toggle);
+      });
+      expect(mockShowAlertSetValue).toHaveBeenCalledWith(true);
+    });
+
+    it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u3092ON\u304B\u3089OFF\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
+      renderSetting({protectForm: true});
+      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      await act(async () => {
+        fireEvent.click(toggle);
+      });
+      expect(mockProtectFormSetValue).toHaveBeenCalledWith(false);
+    });
+
+    it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u3092OFF\u304B\u3089ON\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
+      renderSetting({protectForm: false});
+      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      await act(async () => {
+        fireEvent.click(toggle);
+      });
+      expect(mockProtectFormSetValue).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("\u9664\u5916\u30EA\u30B9\u30C8\u524A\u9664", () => {
+    it("\u4E2D\u9593\u306E\u9805\u76EE\u3092\u524A\u9664\u3067\u304D\u308B", async () => {
+      renderSetting({ignoreList: ["owner/repo-a", "org/*", "user/repo-b"]});
+      const deleteButton = screen.getByRole("button", { name: "org/* \u3092\u524A\u9664" });
+      await act(async () => {
+        fireEvent.click(deleteButton);
+      });
+      expect(mockIgnoreListSetValue).toHaveBeenCalledWith(["owner/repo-a", "user/repo-b"]);
+    });
+
+    it("\u5148\u982D\u306E\u9805\u76EE\u3092\u524A\u9664\u3067\u304D\u308B", async () => {
+      renderSetting({ignoreList: ["owner/repo-a", "org/*"]});
+      const deleteButton = screen.getByRole("button", { name: "owner/repo-a \u3092\u524A\u9664" });
+      await act(async () => {
+        fireEvent.click(deleteButton);
+      });
+      expect(mockIgnoreListSetValue).toHaveBeenCalledWith(["org/*"]);
+    });
+
+    it("\u6700\u5F8C\u306E1\u4EF6\u3092\u524A\u9664\u3067\u304D\u308B", async () => {
+      renderSetting({ignoreList: ["owner/repo-a"]});
+      const deleteButton = screen.getByRole("button", { name: "owner/repo-a \u3092\u524A\u9664" });
+      await act(async () => {
+        fireEvent.click(deleteButton);
+      });
+      expect(mockIgnoreListSetValue).toHaveBeenCalledWith([]);
+    });
+
+    it("\u524A\u9664\u5F8C\u306BUI\u304B\u3089\u8A72\u5F53\u9805\u76EE\u304C\u6D88\u3048\u308B", async () => {
+      renderSetting({ignoreList: ["owner/repo-a", "org/*"]});
+      const deleteButton = screen.getByRole("button", { name: "owner/repo-a \u3092\u524A\u9664" });
+      await act(async () => {
+        fireEvent.click(deleteButton);
+      });
+      expect(screen.queryByText("owner/repo-a")).not.toBeInTheDocument();
+      expect(screen.getByText("org/*")).toBeInTheDocument();
+    });
+  });
+
+  describe("\u9664\u5916\u30EA\u30B9\u30C8\u8FFD\u52A0", () => {
+    function getInput() {
+      return screen.getByPlaceholderText("owner/repo");
+    }
+
+    function getAddButton() {
+      return screen.getByRole("button", { name: "\u8FFD\u52A0" });
+    }
+
+    async function addPattern(value: string) {
+      fireEvent.change(getInput(), { target: { value } });
+      await act(async () => {
+        fireEvent.click(getAddButton());
       });
     }
 
-    it("フォーム送信後にSavedボタンに切り替わる", async () => {
-      await submitForm();
-
-      const savedButton = screen.getByRole("button", { name: "Saved" });
-      expect(savedButton).toBeDisabled();
+    it("owner/repo\u5F62\u5F0F\u306E\u30D1\u30BF\u30FC\u30F3\u3092\u8FFD\u52A0\u3067\u304D\u308B", async () => {
+      renderSetting({ignoreList: ["existing/repo"]});
+      await addPattern("new-owner/new-repo");
+      expect(mockIgnoreListSetValue).toHaveBeenCalledWith(["existing/repo", "new-owner/new-repo"]);
     });
 
-    it("Savedボタンが3秒後にSaveボタンに戻る", async () => {
-      await submitForm();
-
-      expect(screen.getByRole("button", { name: "Saved" })).toBeInTheDocument();
-
-      await act(async () => {
-        vi.advanceTimersByTime(3000);
-      });
-
-      const saveButton = screen.getByRole("button", { name: "Save" });
-      expect(saveButton).toBeEnabled();
+    it("owner/*\u5F62\u5F0F\u306E\u30D1\u30BF\u30FC\u30F3\u3092\u8FFD\u52A0\u3067\u304D\u308B", async () => {
+      renderSetting({ignoreList: []});
+      await addPattern("org-name/*");
+      expect(mockIgnoreListSetValue).toHaveBeenCalledWith(["org-name/*"]);
     });
 
-    it("Savedボタンが3秒未満ではSaveに戻らない", async () => {
-      await submitForm();
+    it("\u8FFD\u52A0\u5F8C\u306BUI\u306E\u4E00\u89A7\u306B\u65B0\u3057\u3044\u30D1\u30BF\u30FC\u30F3\u304C\u8868\u793A\u3055\u308C\u308B", async () => {
+      renderSetting({ignoreList: []});
+      await addPattern("owner/repo");
+      expect(screen.getByText("owner/repo")).toBeInTheDocument();
+    });
 
+    it("\u8FFD\u52A0\u5F8C\u306B\u5165\u529B\u6B04\u304C\u30AF\u30EA\u30A2\u3055\u308C\u308B", async () => {
+      renderSetting({ignoreList: []});
+      await addPattern("owner/repo");
+      expect(getInput()).toHaveValue("");
+    });
+  });
+
+  describe("\u9664\u5916\u30EA\u30B9\u30C8\u8FFD\u52A0 \u30D0\u30EA\u30C7\u30FC\u30B7\u30E7\u30F3", () => {
+    function getInput() {
+      return screen.getByPlaceholderText("owner/repo");
+    }
+
+    function getAddButton() {
+      return screen.getByRole("button", { name: "\u8FFD\u52A0" });
+    }
+
+    async function addPattern(value: string) {
+      fireEvent.change(getInput(), { target: { value } });
       await act(async () => {
-        vi.advanceTimersByTime(2999);
+        fireEvent.click(getAddButton());
       });
+    }
 
-      expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+    it("\u7A7A\u6587\u5B57\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await act(async () => {
+        fireEvent.click(getAddButton());
+      });
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+    });
+
+    it("\u7A7A\u767D\u306E\u307F\u306E\u5165\u529B\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await addPattern("   ");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+    });
+
+    it("\u30B9\u30E9\u30C3\u30B7\u30E5\u3092\u542B\u307E\u306A\u3044\u6587\u5B57\u5217\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await addPattern("invalid-pattern");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(FORMAT_ERROR)).toBeInTheDocument();
+    });
+
+    it("\u30B9\u30E9\u30C3\u30B7\u30E5\u306E\u307F\u306E\u5165\u529B\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await addPattern("/");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(FORMAT_ERROR)).toBeInTheDocument();
+    });
+
+    it("owner\u304C\u7A7A\u306E\u30D1\u30BF\u30FC\u30F3\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await addPattern("/repo");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(FORMAT_ERROR)).toBeInTheDocument();
+    });
+
+    it("repo\u304C\u7A7A\u306E\u30D1\u30BF\u30FC\u30F3\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await addPattern("owner/");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(FORMAT_ERROR)).toBeInTheDocument();
+    });
+
+    it("\u91CD\u8907\u30D1\u30BF\u30FC\u30F3\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044\uFF08\u5B8C\u5168\u4E00\u81F4\uFF09", async () => {
+      renderSetting({ignoreList: ["owner/repo"]});
+      await addPattern("owner/repo");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+    });
+
+    it("\u91CD\u8907\u30D1\u30BF\u30FC\u30F3\u306F\u5927\u6587\u5B57\u5C0F\u6587\u5B57\u3092\u533A\u5225\u3057\u306A\u3044", async () => {
+      renderSetting({ignoreList: ["Owner/Repo"]});
+      await addPattern("owner/repo");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+    });
+
+    it("\u30EF\u30A4\u30EB\u30C9\u30AB\u30FC\u30C9\u30D1\u30BF\u30FC\u30F3\u306E\u91CD\u8907\u30C1\u30A7\u30C3\u30AF", async () => {
+      renderSetting({ignoreList: ["org/*"]});
+      await addPattern("ORG/*");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+    });
+
+    it("\u5165\u529B\u5024\u306E\u524D\u5F8C\u306E\u7A7A\u767D\u306F\u30C8\u30EA\u30E0\u3055\u308C\u3066\u8FFD\u52A0\u3055\u308C\u308B", async () => {
+      renderSetting();
+      await addPattern("  owner/repo  ");
+      expect(mockIgnoreListSetValue).toHaveBeenCalledWith(["owner/repo"]);
     });
   });
 });

--- a/entrypoints/options/Setting.test.tsx
+++ b/entrypoints/options/Setting.test.tsx
@@ -286,6 +286,20 @@ describe("Setting", () => {
       expect(screen.getByText(FORMAT_ERROR)).toBeInTheDocument();
     });
 
+    it("\u30B9\u30E9\u30C3\u30B7\u30E5\u304C\u8907\u6570\u542B\u307E\u308C\u308B\u30D1\u30BF\u30FC\u30F3\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await addPattern("owner/repo/extra");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(FORMAT_ERROR)).toBeInTheDocument();
+    });
+
+    it("\u30EF\u30A4\u30EB\u30C9\u30AB\u30FC\u30C9\u304C\u672B\u5C3E\u306E/*\u3067\u306A\u3044\u30D1\u30BF\u30FC\u30F3\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044", async () => {
+      renderSetting();
+      await addPattern("owner/*foo");
+      expect(mockIgnoreListSetValue).not.toHaveBeenCalled();
+      expect(screen.getByText(FORMAT_ERROR)).toBeInTheDocument();
+    });
+
     it("\u91CD\u8907\u30D1\u30BF\u30FC\u30F3\u306F\u8FFD\u52A0\u3067\u304D\u306A\u3044\uFF08\u5B8C\u5168\u4E00\u81F4\uFF09", async () => {
       renderSetting({ignoreList: ["owner/repo"]});
       await addPattern("owner/repo");

--- a/entrypoints/options/Setting.test.tsx
+++ b/entrypoints/options/Setting.test.tsx
@@ -35,8 +35,8 @@ function renderSetting({showAlert = true, protectForm = true, ignoreList = []}: 
   );
 }
 
-const FORMAT_ERROR = "owner/repo \u307E\u305F\u306F owner/* \u306E\u5F62\u5F0F\u3067\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044";
-const DUPLICATE_ERROR = "\u3053\u306E\u30D1\u30BF\u30FC\u30F3\u306F\u65E2\u306B\u767B\u9332\u3055\u308C\u3066\u3044\u307E\u3059";
+const FORMAT_ERROR = "Please enter in owner/repo or owner/* format.";
+const DUPLICATE_ERROR = "This pattern is already registered.";
 
 describe("Setting", () => {
   beforeEach(() => {
@@ -66,25 +66,25 @@ describe("Setting", () => {
 
     it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u30C8\u30B0\u30EB\u304CON\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
       renderSetting({showAlert: true});
-      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+      const toggle = screen.getByLabelText("Show Alert");
       expect(toggle).toHaveAttribute("aria-pressed", "true");
     });
 
     it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u30C8\u30B0\u30EB\u304COFF\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
       renderSetting({showAlert: false});
-      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+      const toggle = screen.getByLabelText("Show Alert");
       expect(toggle).toHaveAttribute("aria-pressed", "false");
     });
 
     it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u30C8\u30B0\u30EB\u304CON\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
       renderSetting({protectForm: true});
-      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      const toggle = screen.getByLabelText("Protect Form");
       expect(toggle).toHaveAttribute("aria-pressed", "true");
     });
 
     it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u30C8\u30B0\u30EB\u304COFF\u72B6\u614B\u3067\u8868\u793A\u3055\u308C\u308B", () => {
       renderSetting({protectForm: false});
-      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      const toggle = screen.getByLabelText("Protect Form");
       expect(toggle).toHaveAttribute("aria-pressed", "false");
     });
 
@@ -113,7 +113,7 @@ describe("Setting", () => {
   describe("\u30C8\u30B0\u30EB\u64CD\u4F5C", () => {
     it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u3092ON\u304B\u3089OFF\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
       renderSetting({showAlert: true});
-      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+      const toggle = screen.getByLabelText("Show Alert");
       await act(async () => {
         fireEvent.click(toggle);
       });
@@ -122,7 +122,7 @@ describe("Setting", () => {
 
     it("\u30A2\u30E9\u30FC\u30C8\u8868\u793A\u3092OFF\u304B\u3089ON\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
       renderSetting({showAlert: false});
-      const toggle = screen.getByLabelText("\u30A2\u30E9\u30FC\u30C8\u8868\u793A");
+      const toggle = screen.getByLabelText("Show Alert");
       await act(async () => {
         fireEvent.click(toggle);
       });
@@ -131,7 +131,7 @@ describe("Setting", () => {
 
     it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u3092ON\u304B\u3089OFF\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
       renderSetting({protectForm: true});
-      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      const toggle = screen.getByLabelText("Protect Form");
       await act(async () => {
         fireEvent.click(toggle);
       });
@@ -140,7 +140,7 @@ describe("Setting", () => {
 
     it("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77\u3092OFF\u304B\u3089ON\u306B\u5207\u308A\u66FF\u3048\u308B\u3068storage\u306B\u5373\u6642\u53CD\u6620\u3055\u308C\u308B", async () => {
       renderSetting({protectForm: false});
-      const toggle = screen.getByLabelText("\u30D5\u30A9\u30FC\u30E0\u4FDD\u8B77");
+      const toggle = screen.getByLabelText("Protect Form");
       await act(async () => {
         fireEvent.click(toggle);
       });
@@ -151,7 +151,7 @@ describe("Setting", () => {
   describe("\u9664\u5916\u30EA\u30B9\u30C8\u524A\u9664", () => {
     it("\u4E2D\u9593\u306E\u9805\u76EE\u3092\u524A\u9664\u3067\u304D\u308B", async () => {
       renderSetting({ignoreList: ["owner/repo-a", "org/*", "user/repo-b"]});
-      const deleteButton = screen.getByRole("button", { name: "org/* \u3092\u524A\u9664" });
+      const deleteButton = screen.getByRole("button", { name: "Delete org/*" });
       await act(async () => {
         fireEvent.click(deleteButton);
       });
@@ -160,7 +160,7 @@ describe("Setting", () => {
 
     it("\u5148\u982D\u306E\u9805\u76EE\u3092\u524A\u9664\u3067\u304D\u308B", async () => {
       renderSetting({ignoreList: ["owner/repo-a", "org/*"]});
-      const deleteButton = screen.getByRole("button", { name: "owner/repo-a \u3092\u524A\u9664" });
+      const deleteButton = screen.getByRole("button", { name: "Delete owner/repo-a" });
       await act(async () => {
         fireEvent.click(deleteButton);
       });
@@ -169,7 +169,7 @@ describe("Setting", () => {
 
     it("\u6700\u5F8C\u306E1\u4EF6\u3092\u524A\u9664\u3067\u304D\u308B", async () => {
       renderSetting({ignoreList: ["owner/repo-a"]});
-      const deleteButton = screen.getByRole("button", { name: "owner/repo-a \u3092\u524A\u9664" });
+      const deleteButton = screen.getByRole("button", { name: "Delete owner/repo-a" });
       await act(async () => {
         fireEvent.click(deleteButton);
       });
@@ -178,7 +178,7 @@ describe("Setting", () => {
 
     it("\u524A\u9664\u5F8C\u306BUI\u304B\u3089\u8A72\u5F53\u9805\u76EE\u304C\u6D88\u3048\u308B", async () => {
       renderSetting({ignoreList: ["owner/repo-a", "org/*"]});
-      const deleteButton = screen.getByRole("button", { name: "owner/repo-a \u3092\u524A\u9664" });
+      const deleteButton = screen.getByRole("button", { name: "Delete owner/repo-a" });
       await act(async () => {
         fireEvent.click(deleteButton);
       });
@@ -189,11 +189,11 @@ describe("Setting", () => {
 
   describe("\u9664\u5916\u30EA\u30B9\u30C8\u8FFD\u52A0", () => {
     function getInput() {
-      return screen.getByPlaceholderText("owner/repo");
+      return screen.getByPlaceholderText("owner/repo or owner/*");
     }
 
     function getAddButton() {
-      return screen.getByRole("button", { name: "\u8FFD\u52A0" });
+      return screen.getByRole("button", { name: "Add New" });
     }
 
     async function addPattern(value: string) {
@@ -230,11 +230,11 @@ describe("Setting", () => {
 
   describe("\u9664\u5916\u30EA\u30B9\u30C8\u8FFD\u52A0 \u30D0\u30EA\u30C7\u30FC\u30B7\u30E7\u30F3", () => {
     function getInput() {
-      return screen.getByPlaceholderText("owner/repo");
+      return screen.getByPlaceholderText("owner/repo or owner/*");
     }
 
     function getAddButton() {
-      return screen.getByRole("button", { name: "\u8FFD\u52A0" });
+      return screen.getByRole("button", { name: "Add New" });
     }
 
     async function addPattern(value: string) {

--- a/entrypoints/options/Setting.tsx
+++ b/entrypoints/options/Setting.tsx
@@ -110,11 +110,12 @@ export const Setting: React.FC<Props> = ({showAlert: initialShowAlert, protectFo
         <div style={{padding: "16px 20px"}}>
           <form onSubmit={handleAddPattern}>
             <FormControl>
-              <FormControl.Label visuallyHidden>Add pattern</FormControl.Label>
+              <FormControl.Label htmlFor="add-pattern-input" visuallyHidden>Add pattern</FormControl.Label>
               <div style={{display: "flex", gap: 8}}>
                 <div style={{position: "relative", flex: 1}}>
                   <span style={{position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: "var(--fgColor-muted, #656d76)", pointerEvents: "none", display: "flex"}}><PlusIcon size={16} /></span>
                   <input
+                    id="add-pattern-input"
                     type="text"
                     placeholder="owner/repo or owner/*"
                     value={input}

--- a/entrypoints/options/Setting.tsx
+++ b/entrypoints/options/Setting.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import {Button, Flash, FormControl, Heading, TextInput, ToggleSwitch} from "@primer/react";
-import {TrashIcon, MarkGithubIcon} from "@primer/octicons-react";
+import {Flash, FormControl, Heading, ToggleSwitch} from "@primer/react";
+import {TrashIcon, MarkGithubIcon, PlusIcon} from "@primer/octicons-react";
 import {showAlertItem, protectFormItem, ignoreListItem} from "@/utils/storage";
 
 type Props = {
@@ -15,10 +15,10 @@ function validatePattern(value: string, currentList: string[]): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
   if (!/^[^/]+\/(\*|[^/*]+)$/.test(trimmed)) {
-    return "owner/repo または owner/* の形式で入力してください";
+    return "Please enter in owner/repo or owner/* format.";
   }
   if (currentList.some(p => p.toLowerCase() === trimmed.toLowerCase())) {
-    return "このパターンは既に登録されています";
+    return "This pattern is already registered.";
   }
   return "";
 }
@@ -65,78 +65,99 @@ export const Setting: React.FC<Props> = ({showAlert: initialShowAlert, protectFo
   };
 
   return (
-    <div style={{maxWidth: 720, margin: "0 auto", padding: "0 16px"}}>
-      <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24}}>
-        <Heading>Public repo Alert Settings</Heading>
+    <div style={{maxWidth: 600, margin: "0 auto", padding: "32px 24px"}}>
+      <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 32}}>
+        <Heading style={{fontSize: 24}}>Public repo Alert Settings</Heading>
         <a href={REPO_URL} target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
           <MarkGithubIcon size={24} />
         </a>
       </div>
 
-      <section style={{marginBottom: 24}}>
-        <Heading as="h3" style={{fontSize: 16, marginBottom: 16}}>機能設定</Heading>
-        <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0"}}>
-          <span id="show-alert-label">アラート表示</span>
-          <ToggleSwitch
-            aria-labelledby="show-alert-label"
-            checked={showAlert}
-            onClick={handleToggleShowAlert}
-          />
+      <section style={{marginBottom: 32, borderRadius: 6, border: "1px solid var(--borderColor-default, #d0d7de)", overflow: "hidden"}}>
+        <div style={{padding: "12px 20px", background: "var(--bgColor-muted, #f6f8fa)", borderBottom: "1px solid var(--borderColor-default, #d0d7de)"}}>
+          <Heading as="h3" style={{fontSize: 16, margin: 0}}>Features</Heading>
         </div>
-        <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0"}}>
-          <span id="protect-form-label">フォーム保護</span>
-          <ToggleSwitch
-            aria-labelledby="protect-form-label"
-            checked={protectForm}
-            onClick={handleToggleProtectForm}
-          />
+        <div style={{padding: "0 20px"}}>
+          <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 0", borderBottom: "1px solid var(--borderColor-muted, #d8dee4)"}}>
+            <div>
+              <div id="show-alert-label" style={{fontSize: 15, fontWeight: 600}}>Show Alert</div>
+              <div style={{fontSize: 13, color: "var(--fgColor-muted, #656d76)", marginTop: 2}}>Display a warning bar when viewing public repositories</div>
+            </div>
+            <ToggleSwitch
+              aria-labelledby="show-alert-label"
+              checked={showAlert}
+              onClick={handleToggleShowAlert}
+            />
+          </div>
+          <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 0"}}>
+            <div>
+              <div id="protect-form-label" style={{fontSize: 15, fontWeight: 600}}>Protect Form</div>
+              <div style={{fontSize: 13, color: "var(--fgColor-muted, #656d76)", marginTop: 2}}>Hide comment forms to prevent accidental posts</div>
+            </div>
+            <ToggleSwitch
+              aria-labelledby="protect-form-label"
+              checked={protectForm}
+              onClick={handleToggleProtectForm}
+            />
+          </div>
         </div>
       </section>
 
-      <section>
-        <Heading as="h3" style={{fontSize: 16, marginBottom: 16}}>除外リスト</Heading>
-        {ignoreList.length > 0 && (
-          <ul style={{listStyle: "none", padding: 0, margin: "0 0 16px 0"}}>
-            {ignoreList.map((pattern, index) => (
-              <li
-                key={pattern}
-                style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0", borderBottom: "1px solid var(--borderColor-default, #d0d7de)"}}
-              >
-                <code>{pattern}</code>
-                <Button
-                  variant="danger"
-                  size="small"
-                  aria-label={`${pattern} を削除`}
-                  onClick={() => handleRemovePattern(index)}
-                  leadingVisual={TrashIcon}
+      <section style={{borderRadius: 6, border: "1px solid var(--borderColor-default, #d0d7de)", overflow: "hidden"}}>
+        <div style={{padding: "12px 20px", background: "var(--bgColor-muted, #f6f8fa)", borderBottom: "1px solid var(--borderColor-default, #d0d7de)"}}>
+          <Heading as="h3" style={{fontSize: 16, margin: 0}}>Ignore List</Heading>
+        </div>
+        <div style={{padding: "16px 20px"}}>
+          <form onSubmit={handleAddPattern}>
+            <FormControl>
+              <FormControl.Label visuallyHidden>Add pattern</FormControl.Label>
+              <div style={{display: "flex", gap: 8}}>
+                <div style={{position: "relative", flex: 1}}>
+                  <span style={{position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: "var(--fgColor-muted, #656d76)", pointerEvents: "none", display: "flex"}}><PlusIcon size={16} /></span>
+                  <input
+                    type="text"
+                    placeholder="owner/repo or owner/*"
+                    value={input}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      setInput(e.target.value);
+                      if (error) setError("");
+                    }}
+                    style={{width: "100%", padding: "8px 12px 8px 36px", fontSize: 14, border: "1px solid var(--borderColor-default, #d0d7de)", borderRadius: 6, background: "var(--bgColor-default, #fff)", boxSizing: "border-box"}}
+                  />
+                </div>
+                <button type="submit" style={{padding: "8px 16px", fontSize: 14, fontWeight: 600, color: "#fff", background: "#2563eb", border: "1px solid #2563eb", borderRadius: 6, cursor: "pointer", whiteSpace: "nowrap"}}>Add New</button>
+              </div>
+              {error && (
+                <Flash variant="danger" style={{marginTop: 8}}>{error}</Flash>
+              )}
+            </FormControl>
+          </form>
+          {ignoreList.length > 0 && (
+            <ul style={{listStyle: "none", padding: 0, margin: "16px 0 0 0"}}>
+              {ignoreList.map((pattern, index) => (
+                <li
+                  key={pattern}
+                  style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "10px 0", borderBottom: "1px solid var(--borderColor-muted, #d8dee4)"}}
                 >
-                  削除
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-        <form onSubmit={handleAddPattern}>
-          <FormControl>
-            <FormControl.Label>パターンを追加</FormControl.Label>
-            <FormControl.Caption>owner/repo または owner/* の形式で入力</FormControl.Caption>
-            <div style={{display: "flex", gap: 8}}>
-              <TextInput
-                placeholder="owner/repo"
-                value={input}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  setInput(e.target.value);
-                  if (error) setError("");
-                }}
-                block
-              />
-              <Button type="submit">追加</Button>
+                  <span style={{fontSize: 14}}>{pattern}</span>
+                  <button
+                    type="button"
+                    aria-label={`Delete ${pattern}`}
+                    onClick={() => handleRemovePattern(index)}
+                    style={{background: "none", border: "none", cursor: "pointer", padding: 4, color: "#cf222e", display: "flex"}}
+                  >
+                    <TrashIcon size={16} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {ignoreList.length === 0 && (
+            <div style={{marginTop: 16, color: "var(--fgColor-muted, #656d76)", fontSize: 14}}>
+              No items in the ignore list.
             </div>
-            {error && (
-              <Flash variant="danger" style={{marginTop: 8}}>{error}</Flash>
-            )}
-          </FormControl>
-        </form>
+          )}
+        </div>
       </section>
     </div>
   );

--- a/entrypoints/options/Setting.tsx
+++ b/entrypoints/options/Setting.tsx
@@ -14,8 +14,7 @@ const REPO_URL = "https://github.com/tak-solder/public-repo-alert";
 function validatePattern(value: string, currentList: string[]): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
-  const slashIndex = trimmed.indexOf("/");
-  if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
+  if (!/^[^/]+\/(\*|[^/*]+)$/.test(trimmed)) {
     return "owner/repo または owner/* の形式で入力してください";
   }
   if (currentList.some(p => p.toLowerCase() === trimmed.toLowerCase())) {

--- a/entrypoints/options/Setting.tsx
+++ b/entrypoints/options/Setting.tsx
@@ -1,13 +1,7 @@
 import React from "react";
 import {Flash, FormControl, Heading, ToggleSwitch} from "@primer/react";
 import {TrashIcon, MarkGithubIcon, PlusIcon} from "@primer/octicons-react";
-import {showAlertItem, protectFormItem, ignoreListItem} from "@/utils/storage";
-
-type Props = {
-  showAlert: boolean;
-  protectForm: boolean;
-  ignoreList: string[];
-};
+import {type StorageState, showAlertItem, protectFormItem, ignoreListItem} from "@/utils/storage";
 
 const REPO_URL = "https://github.com/tak-solder/public-repo-alert";
 
@@ -23,7 +17,7 @@ function validatePattern(value: string, currentList: string[]): string | null {
   return "";
 }
 
-export const Setting: React.FC<Props> = ({showAlert: initialShowAlert, protectForm: initialProtectForm, ignoreList: initialIgnoreList}) => {
+export const Setting: React.FC<StorageState> = ({showAlert: initialShowAlert, protectForm: initialProtectForm, ignoreList: initialIgnoreList}) => {
   const [showAlert, setShowAlert] = React.useState(initialShowAlert);
   const [protectForm, setProtectForm] = React.useState(initialProtectForm);
   const [ignoreList, setIgnoreList] = React.useState(initialIgnoreList);

--- a/entrypoints/options/Setting.tsx
+++ b/entrypoints/options/Setting.tsx
@@ -1,55 +1,144 @@
 import React from "react";
-import {Button, FormControl, Heading, Textarea} from "@primer/react";
-import {ignoreListItem} from "@/utils/storage";
+import {Button, Flash, FormControl, Heading, TextInput, ToggleSwitch} from "@primer/react";
+import {TrashIcon, MarkGithubIcon} from "@primer/octicons-react";
+import {showAlertItem, protectFormItem, ignoreListItem} from "@/utils/storage";
 
 type Props = {
+  showAlert: boolean;
+  protectForm: boolean;
   ignoreList: string[];
+};
+
+const REPO_URL = "https://github.com/tak-solder/public-repo-alert";
+
+function validatePattern(value: string, currentList: string[]): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
+    return "owner/repo または owner/* の形式で入力してください";
+  }
+  if (currentList.some(p => p.toLowerCase() === trimmed.toLowerCase())) {
+    return "このパターンは既に登録されています";
+  }
+  return "";
 }
 
-const placeholder = `eg. username/repo-name
-username/*`;
+export const Setting: React.FC<Props> = ({showAlert: initialShowAlert, protectForm: initialProtectForm, ignoreList: initialIgnoreList}) => {
+  const [showAlert, setShowAlert] = React.useState(initialShowAlert);
+  const [protectForm, setProtectForm] = React.useState(initialProtectForm);
+  const [ignoreList, setIgnoreList] = React.useState(initialIgnoreList);
+  const [input, setInput] = React.useState("");
+  const [error, setError] = React.useState("");
 
-export const Setting: React.FC<Props> = ({ignoreList}) => {
-  const [saved, setSaved] = React.useState(false);
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleToggleShowAlert = async () => {
+    const newValue = !showAlert;
+    setShowAlert(newValue);
+    await showAlertItem.setValue(newValue);
+  };
+
+  const handleToggleProtectForm = async () => {
+    const newValue = !protectForm;
+    setProtectForm(newValue);
+    await protectFormItem.setValue(newValue);
+  };
+
+  const handleRemovePattern = async (index: number) => {
+    const newList = ignoreList.filter((_, i) => i !== index);
+    setIgnoreList(newList);
+    await ignoreListItem.setValue(newList);
+  };
+
+  const handleAddPattern = async (e: React.FormEvent) => {
     e.preventDefault();
-    const textarea = e.currentTarget.querySelector<HTMLTextAreaElement>('textarea#ignore-repository-input');
-    const value = textarea?.value || '';
-    const patterns = value.split(/(\r\n|\r|\n)/).map(v => v.trim()).filter(v => v);
-    await ignoreListItem.setValue(patterns);
-    setSaved(true);
-    setTimeout(() => {
-      setSaved(false);
-    },3000);
+    const result = validatePattern(input, ignoreList);
+    if (result === null) return;
+    if (result !== "") {
+      setError(result);
+      return;
+    }
+    const trimmed = input.trim();
+    const newList = [...ignoreList, trimmed];
+    setIgnoreList(newList);
+    setInput("");
+    setError("");
+    await ignoreListItem.setValue(newList);
   };
 
   return (
-    <div style={{maxWidth: '720px', margin: '0 auto', padding: '0 16px'}}>
-      <Heading>Public repo Alert Settings</Heading>
-      <form onSubmit={handleSubmit}>
-        <FormControl id="ignore-repository-input">
-          <FormControl.Label style={{fontSize: "x-large"}}>
-              Ignore Repositories
-          </FormControl.Label>
-          <FormControl.Caption style={{fontSize: "medium"}}>
-            Specify the repository where you want to disable this feature.<br/>
-            You can specify one per line. Use username/* to match all repositories of a user.
-          </FormControl.Caption>
-          <Textarea style={{height: '250px'}}
-                    defaultValue={ignoreList.join("\n")}
-                    placeholder={placeholder}
-                    block
-          />
-        </FormControl>
-        <FormControl style={{marginTop: '16px'}}>
-          {saved ? (
-            <Button type="button" size="large" variant="primary" style={{fontSize: "large"}} disabled>Saved</Button>
-          ) : (
-            <Button type="submit" size="large" variant="primary" style={{fontSize: "large"}}>Save</Button>
-          )}
+    <div style={{maxWidth: 720, margin: "0 auto", padding: "0 16px"}}>
+      <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24}}>
+        <Heading>Public repo Alert Settings</Heading>
+        <a href={REPO_URL} target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
+          <MarkGithubIcon size={24} />
+        </a>
+      </div>
 
-        </FormControl>
-      </form>
+      <section style={{marginBottom: 24}}>
+        <Heading as="h3" style={{fontSize: 16, marginBottom: 16}}>機能設定</Heading>
+        <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0"}}>
+          <span id="show-alert-label">アラート表示</span>
+          <ToggleSwitch
+            aria-labelledby="show-alert-label"
+            checked={showAlert}
+            onClick={handleToggleShowAlert}
+          />
+        </div>
+        <div style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0"}}>
+          <span id="protect-form-label">フォーム保護</span>
+          <ToggleSwitch
+            aria-labelledby="protect-form-label"
+            checked={protectForm}
+            onClick={handleToggleProtectForm}
+          />
+        </div>
+      </section>
+
+      <section>
+        <Heading as="h3" style={{fontSize: 16, marginBottom: 16}}>除外リスト</Heading>
+        {ignoreList.length > 0 && (
+          <ul style={{listStyle: "none", padding: 0, margin: "0 0 16px 0"}}>
+            {ignoreList.map((pattern, index) => (
+              <li
+                key={pattern}
+                style={{display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0", borderBottom: "1px solid var(--borderColor-default, #d0d7de)"}}
+              >
+                <code>{pattern}</code>
+                <Button
+                  variant="danger"
+                  size="small"
+                  aria-label={`${pattern} を削除`}
+                  onClick={() => handleRemovePattern(index)}
+                  leadingVisual={TrashIcon}
+                >
+                  削除
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <form onSubmit={handleAddPattern}>
+          <FormControl>
+            <FormControl.Label>パターンを追加</FormControl.Label>
+            <FormControl.Caption>owner/repo または owner/* の形式で入力</FormControl.Caption>
+            <div style={{display: "flex", gap: 8}}>
+              <TextInput
+                placeholder="owner/repo"
+                value={input}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setInput(e.target.value);
+                  if (error) setError("");
+                }}
+                block
+              />
+              <Button type="submit">追加</Button>
+            </div>
+            {error && (
+              <Flash variant="danger" style={{marginTop: 8}}>{error}</Flash>
+            )}
+          </FormControl>
+        </form>
+      </section>
     </div>
   );
 };

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,5 +1,12 @@
 import {storage} from "wxt/utils/storage";
 
+/** ストレージに保存される設定の型 */
+export type StorageState = {
+  showAlert: boolean;
+  protectForm: boolean;
+  ignoreList: string[];
+};
+
 /** アラート表示のON/OFF */
 export const showAlertItem = storage.defineItem<boolean>("local:showAlert", {
   fallback: true,


### PR DESCRIPTION
## Summary
- Setting.tsxを全面改修し、カードヘッダー+ボディのセクション分割レイアウトに変更
- Featuresセクション: Show Alert / Protect FormのToggleSwitchトグルUI（機能説明文付き）
- Ignore Listセクション: 入力フォーム + 一覧表示・個別削除（ゴミ箱アイコン）
- バリデーション: `owner/repo` or `owner/*` 形式チェック、重複チェック（大文字小文字区別なし）
- 保存方式を即時反映に変更（Saveボタン廃止）
- GitHubリポジトリへのリンクを追加
- App.tsxで3つのstorageアイテムをPromise.allで並列読み込み
- 全テキストを英語に統一

## Test plan
- [x] typecheck パス
- [x] lint パス
- [x] 全113テストパス（App: 6件, Setting: 34件, 既存テスト: 73件）
- [x] build 成功
- [ ] ブラウザでオプションページの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)