### PR TITLE
Build 03: アラートバー除外登録

### DIFF
--- a/entrypoints/content/BottomNotification.test.tsx
+++ b/entrypoints/content/BottomNotification.test.tsx
@@ -7,23 +7,28 @@ import { OctolyticsProvider } from "./octolytics";
 const mockShowAlertGetValue = vi.fn();
 const mockProtectFormGetValue = vi.fn();
 const mockIgnoreListGetValue = vi.fn();
+const mockShowAlertWatch = vi.fn();
+const mockProtectFormWatch = vi.fn();
+const mockIgnoreListWatch = vi.fn();
+const mockAddIgnorePattern = vi.fn();
 
 vi.mock("@/utils/storage", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/storage")>();
   return {
     showAlertItem: {
       getValue: () => mockShowAlertGetValue(),
-      watch: () => () => {},
+      watch: (cb: unknown) => mockShowAlertWatch(cb),
     },
     protectFormItem: {
       getValue: () => mockProtectFormGetValue(),
-      watch: () => () => {},
+      watch: (cb: unknown) => mockProtectFormWatch(cb),
     },
     ignoreListItem: {
       getValue: () => mockIgnoreListGetValue(),
-      watch: () => () => {},
+      watch: (cb: unknown) => mockIgnoreListWatch(cb),
     },
     isIgnored: actual.isIgnored,
+    addIgnorePattern: (...args: unknown[]) => mockAddIgnorePattern(...args),
   };
 });
 
@@ -49,6 +54,7 @@ function setupDefaultStorage() {
   mockShowAlertGetValue.mockResolvedValue(true);
   mockProtectFormGetValue.mockResolvedValue(true);
   mockIgnoreListGetValue.mockResolvedValue([]);
+  mockAddIgnorePattern.mockResolvedValue(true);
 }
 
 function renderWithProvider() {
@@ -64,6 +70,13 @@ describe("BottomNotification", () => {
     mockShowAlertGetValue.mockReset();
     mockProtectFormGetValue.mockReset();
     mockIgnoreListGetValue.mockReset();
+    mockShowAlertWatch.mockReset();
+    mockProtectFormWatch.mockReset();
+    mockIgnoreListWatch.mockReset();
+    mockAddIgnorePattern.mockReset();
+    mockShowAlertWatch.mockReturnValue(() => {});
+    mockProtectFormWatch.mockReturnValue(() => {});
+    mockIgnoreListWatch.mockReturnValue(() => {});
   });
 
   afterEach(() => {
@@ -229,6 +242,94 @@ describe("BottomNotification", () => {
     });
 
     expect(screen.getByText("This repository is public")).toBeInTheDocument();
+  });
+
+  it("アラートバー内に IgnoreMenu が表示される", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    setupDefaultStorage();
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    expect(screen.getByLabelText("Ignore options")).toBeInTheDocument();
+  });
+
+  it("IgnoreMenu に正しい repositoryName が渡される", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "my-org/my-repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    setupDefaultStorage();
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Ignore this repository"));
+    });
+
+    expect(mockAddIgnorePattern).toHaveBeenCalledWith("my-org/my-repo");
+  });
+
+  it("除外登録後にアラートが即座に非表示になる（owner/repo）", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    setupDefaultStorage();
+
+    let ignoreListWatchCallback: ((newValue: string[]) => void) | undefined;
+    mockIgnoreListWatch.mockImplementation((cb: (newValue: string[]) => void) => {
+      ignoreListWatchCallback = cb;
+      return () => {};
+    });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    expect(screen.getByText("This repository is public")).toBeInTheDocument();
+
+    await act(async () => {
+      ignoreListWatchCallback!(["owner/repo"]);
+    });
+
+    expect(screen.queryByText("This repository is public")).not.toBeInTheDocument();
+  });
+
+  it("除外登録後にアラートが即座に非表示になる（owner/*）", async () => {
+    setMetaTags({
+      "octolytics-dimension-repository_nwo": "owner/repo",
+      "octolytics-dimension-repository_public": "true",
+    });
+    setupDefaultStorage();
+
+    let ignoreListWatchCallback: ((newValue: string[]) => void) | undefined;
+    mockIgnoreListWatch.mockImplementation((cb: (newValue: string[]) => void) => {
+      ignoreListWatchCallback = cb;
+      return () => {};
+    });
+
+    await act(async () => {
+      renderWithProvider();
+    });
+
+    expect(screen.getByText("This repository is public")).toBeInTheDocument();
+
+    await act(async () => {
+      ignoreListWatchCallback!(["owner/*"]);
+    });
+
+    expect(screen.queryByText("This repository is public")).not.toBeInTheDocument();
   });
 
   it("protectForm が false でも showAlert が true なら通知が表示される", async () => {

--- a/entrypoints/content/BottomNotification.tsx
+++ b/entrypoints/content/BottomNotification.tsx
@@ -1,6 +1,7 @@
 import {FC, useEffect, useRef, useState} from "react";
 import {useBoolean} from "@/hooks/useBoolean";
 import {useOctolytics} from "./octolytics";
+import {IgnoreMenu} from "./IgnoreMenu";
 
 export const BottomNotification: FC = () => {
   const [hidden, {setTrue: handleCloseButton, setFalse: resetHidden}] = useBoolean(false)
@@ -35,6 +36,9 @@ export const BottomNotification: FC = () => {
       <div className="position-fixed bottom-0 width-full" ref={fixedDivRef}>
         <div className="flash flash-error flash-full border-bottom-0 text-center text-bold py-2">
           <div className="flash-action d-flex flex-items-center">
+            {octolytics.repositoryName && (
+              <IgnoreMenu repositoryName={octolytics.repositoryName} />
+            )}
             <button className="flash-close Button Button--iconOnly Button--invisible Button--medium" type="submit"
                     aria-label="Close" onClick={handleCloseButton}>
               {/* https://primer.style/foundations/icons/x-16 */}

--- a/entrypoints/content/IgnoreMenu.test.tsx
+++ b/entrypoints/content/IgnoreMenu.test.tsx
@@ -1,0 +1,116 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest";
+import {render, screen, act, cleanup, fireEvent} from "@testing-library/react";
+import {IgnoreMenu} from "./IgnoreMenu";
+
+const mockAddIgnorePattern = vi.fn();
+
+vi.mock("@/utils/storage", () => ({
+  addIgnorePattern: (...args: unknown[]) => mockAddIgnorePattern(...args),
+}));
+
+describe("IgnoreMenu", () => {
+  beforeEach(() => {
+    mockAddIgnorePattern.mockReset();
+    mockAddIgnorePattern.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("3点メニューアイコンが表示される", () => {
+    render(<IgnoreMenu repositoryName="owner/repo" />);
+    expect(screen.getByLabelText("Ignore options")).toBeInTheDocument();
+  });
+
+  it("ボタンクリックでドロップダウンメニューが開く", async () => {
+    render(<IgnoreMenu repositoryName="owner/repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+
+    expect(screen.getByText("Ignore this repository")).toBeInTheDocument();
+    expect(screen.getByText("Ignore this owner's repositories")).toBeInTheDocument();
+  });
+
+  it("メニューが開いた状態でボタンを再クリックするとメニューが閉じる", async () => {
+    render(<IgnoreMenu repositoryName="owner/repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+    expect(screen.getByText("Ignore this repository")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+    expect(screen.queryByText("Ignore this repository")).not.toBeInTheDocument();
+  });
+
+  it("メニュー外をクリックするとメニューが閉じる", async () => {
+    render(<IgnoreMenu repositoryName="owner/repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+    expect(screen.getByText("Ignore this repository")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(document.body);
+    });
+    expect(screen.queryByText("Ignore this repository")).not.toBeInTheDocument();
+  });
+
+  it("Ignore this repository を選択すると owner/repo 形式で除外登録される", async () => {
+    render(<IgnoreMenu repositoryName="owner/repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Ignore this repository"));
+    });
+
+    expect(mockAddIgnorePattern).toHaveBeenCalledWith("owner/repo");
+  });
+
+  it("Ignore this owner's repositories を選択すると owner/* 形式で除外登録される", async () => {
+    render(<IgnoreMenu repositoryName="owner/repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Ignore this owner's repositories"));
+    });
+
+    expect(mockAddIgnorePattern).toHaveBeenCalledWith("owner/*");
+  });
+
+  it("repositoryName が大文字を含む場合でもそのまま渡される", async () => {
+    render(<IgnoreMenu repositoryName="Owner/Repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Ignore this repository"));
+    });
+
+    expect(mockAddIgnorePattern).toHaveBeenCalledWith("Owner/Repo");
+  });
+
+  it("メニュー項目選択後にメニューが閉じる", async () => {
+    render(<IgnoreMenu repositoryName="owner/repo" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Ignore options"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Ignore this repository"));
+    });
+
+    expect(screen.queryByText("Ignore this repository")).not.toBeInTheDocument();
+  });
+});

--- a/entrypoints/content/IgnoreMenu.tsx
+++ b/entrypoints/content/IgnoreMenu.tsx
@@ -1,0 +1,82 @@
+import {FC, useEffect, useRef} from "react";
+import {useBoolean} from "@/hooks/useBoolean";
+import {addIgnorePattern} from "@/utils/storage";
+
+type Props = {
+  repositoryName: string;
+};
+
+export const IgnoreMenu: FC<Props> = ({repositoryName}) => {
+  const [open, {toggle, setFalse: close}] = useBoolean(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // メニュー外クリックで閉じる
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener("click", handleClick, true);
+    return () => document.removeEventListener("click", handleClick, true);
+  }, [open, close]);
+
+  const owner = repositoryName.split("/")[0];
+
+  const handleIgnoreRepo = async () => {
+    await addIgnorePattern(repositoryName);
+    close();
+  };
+
+  const handleIgnoreOwner = async () => {
+    await addIgnorePattern(`${owner}/*`);
+    close();
+  };
+
+  return (
+    <div ref={menuRef} className="position-relative d-inline-block">
+      <button
+        className="Button Button--iconOnly Button--invisible Button--medium"
+        type="button"
+        aria-label="Ignore options"
+        aria-expanded={open}
+        onClick={toggle}
+      >
+        {/* https://primer.style/foundations/icons/kebab-horizontal-16 */}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"
+             className="octicon octicon-kebab-horizontal">
+          <path
+            d="M8 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm13 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path>
+        </svg>
+      </button>
+      {open && (
+        <div
+          className="position-absolute bottom-0 right-0 mb-4 py-1 color-bg-overlay color-shadow-large rounded-2"
+          style={{whiteSpace: "nowrap", zIndex: 100, boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 8px 24px rgba(0,0,0,0.12)"}}
+        >
+          <button
+            className="d-block width-full text-left px-3 py-2 color-fg-default color-bg-overlay border-0"
+            style={{cursor: "pointer", fontSize: "14px", lineHeight: "20px"}}
+            type="button"
+            onClick={handleIgnoreRepo}
+            onMouseEnter={(e) => e.currentTarget.style.backgroundColor = "var(--bgColor-neutral-muted)"}
+            onMouseLeave={(e) => e.currentTarget.style.backgroundColor = ""}
+          >
+            Ignore this repository
+          </button>
+          <button
+            className="d-block width-full text-left px-3 py-2 color-fg-default color-bg-overlay border-0"
+            style={{cursor: "pointer", fontSize: "14px", lineHeight: "20px"}}
+            type="button"
+            onClick={handleIgnoreOwner}
+            onMouseEnter={(e) => e.currentTarget.style.backgroundColor = "var(--bgColor-neutral-muted)"}
+            onMouseLeave={(e) => e.currentTarget.style.backgroundColor = ""}
+          >
+            Ignore this owner's repositories
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -1,5 +1,5 @@
-import {describe, it, expect} from "vitest";
-import {isIgnored} from "./storage";
+import {describe, it, expect, vi, beforeEach} from "vitest";
+import {isIgnored, addIgnorePattern, ignoreListItem} from "./storage";
 
 describe("isIgnored", () => {
   it("完全一致でマッチする場合", () => {
@@ -48,5 +48,74 @@ describe("isIgnored", () => {
 
   it("部分一致ではマッチしない", () => {
     expect(isIgnored("owner/repo-extended", ["owner/repo"])).toBe(false);
+  });
+});
+
+describe("addIgnorePattern", () => {
+  const mockGetValue = vi.fn();
+  const mockSetValue = vi.fn();
+
+  beforeEach(() => {
+    mockGetValue.mockReset();
+    mockSetValue.mockReset();
+    vi.spyOn(ignoreListItem, "getValue").mockImplementation(mockGetValue);
+    vi.spyOn(ignoreListItem, "setValue").mockImplementation(mockSetValue);
+    mockSetValue.mockResolvedValue(undefined);
+  });
+
+  it("空の除外リストに owner/repo 形式のパターンを追加する", async () => {
+    mockGetValue.mockResolvedValue([]);
+    const result = await addIgnorePattern("owner/repo");
+    expect(result).toBe(true);
+    expect(mockSetValue).toHaveBeenCalledWith(["owner/repo"]);
+  });
+
+  it("空の除外リストに owner/* 形式のパターンを追加する", async () => {
+    mockGetValue.mockResolvedValue([]);
+    const result = await addIgnorePattern("owner/*");
+    expect(result).toBe(true);
+    expect(mockSetValue).toHaveBeenCalledWith(["owner/*"]);
+  });
+
+  it("既存のリストに新しいパターンを追記する", async () => {
+    mockGetValue.mockResolvedValue(["alpha/repo"]);
+    const result = await addIgnorePattern("beta/repo");
+    expect(result).toBe(true);
+    expect(mockSetValue).toHaveBeenCalledWith(["alpha/repo", "beta/repo"]);
+  });
+
+  it("完全一致のパターンが既に存在する場合は重複追加しない", async () => {
+    mockGetValue.mockResolvedValue(["owner/repo"]);
+    const result = await addIgnorePattern("owner/repo");
+    expect(result).toBe(false);
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  it("owner/* が既に存在する場合に同一ownerの owner/repo を追加しない", async () => {
+    mockGetValue.mockResolvedValue(["owner/*"]);
+    const result = await addIgnorePattern("owner/repo");
+    expect(result).toBe(false);
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  it("owner/repo が既に存在する場合でも owner/* は追加できる", async () => {
+    mockGetValue.mockResolvedValue(["owner/repo"]);
+    const result = await addIgnorePattern("owner/*");
+    expect(result).toBe(true);
+    expect(mockSetValue).toHaveBeenCalledWith(["owner/repo", "owner/*"]);
+  });
+
+  it("大文字小文字が異なる同一パターンは重複として扱われる", async () => {
+    mockGetValue.mockResolvedValue(["Owner/Repo"]);
+    const result = await addIgnorePattern("owner/repo");
+    expect(result).toBe(false);
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  it("異なるownerの同名リポジトリは重複にならない", async () => {
+    mockGetValue.mockResolvedValue(["alpha/repo"]);
+    const result = await addIgnorePattern("beta/repo");
+    expect(result).toBe(true);
+    expect(mockSetValue).toHaveBeenCalledWith(["alpha/repo", "beta/repo"]);
   });
 });

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from "vitest";
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest";
 import {isIgnored, addIgnorePattern, ignoreListItem} from "./storage";
 
 describe("isIgnored", () => {
@@ -63,6 +63,10 @@ describe("addIgnorePattern", () => {
     mockSetValue.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("空の除外リストに owner/repo 形式のパターンを追加する", async () => {
     mockGetValue.mockResolvedValue([]);
     const result = await addIgnorePattern("owner/repo");
@@ -117,5 +121,26 @@ describe("addIgnorePattern", () => {
     const result = await addIgnorePattern("beta/repo");
     expect(result).toBe(true);
     expect(mockSetValue).toHaveBeenCalledWith(["alpha/repo", "beta/repo"]);
+  });
+
+  it("前後の空白をトリムして保存する", async () => {
+    mockGetValue.mockResolvedValue([]);
+    const result = await addIgnorePattern("  owner/repo  ");
+    expect(result).toBe(true);
+    expect(mockSetValue).toHaveBeenCalledWith(["owner/repo"]);
+  });
+
+  it("形式不正のパターンは追加しない", async () => {
+    const result = await addIgnorePattern("owner");
+    expect(result).toBe(false);
+    expect(mockGetValue).not.toHaveBeenCalled();
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  it("空白のみのパターンは追加しない", async () => {
+    const result = await addIgnorePattern("   ");
+    expect(result).toBe(false);
+    expect(mockGetValue).not.toHaveBeenCalled();
+    expect(mockSetValue).not.toHaveBeenCalled();
   });
 });

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -22,6 +22,17 @@ export const ignoreListItem = storage.defineItem<string[]>("local:ignoreList", {
   fallback: [],
 });
 
+/**
+ * 除外リストにパターンを追加する（既にカバーされている場合は何もしない）
+ * @returns 追加されたかどうか
+ */
+export const addIgnorePattern = async (pattern: string): Promise<boolean> => {
+  const current = await ignoreListItem.getValue();
+  if (isIgnored(pattern, current)) return false;
+  await ignoreListItem.setValue([...current, pattern]);
+  return true;
+};
+
 /** 除外判定（完全一致 + owner/*ワイルドカード、大文字小文字を区別しない） */
 export const isIgnored = (repositoryName: string, ignoreList: string[]): boolean => {
   const repoLower = repositoryName.toLowerCase();

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -22,14 +22,19 @@ export const ignoreListItem = storage.defineItem<string[]>("local:ignoreList", {
   fallback: [],
 });
 
+const ignorePatternFormat = /^[^/]+\/(\*|[^/*]+)$/;
+
 /**
  * 除外リストにパターンを追加する（既にカバーされている場合は何もしない）
  * @returns 追加されたかどうか
  */
 export const addIgnorePattern = async (pattern: string): Promise<boolean> => {
+  const trimmed = pattern.trim();
+  if (!ignorePatternFormat.test(trimmed)) return false;
+
   const current = await ignoreListItem.getValue();
-  if (isIgnored(pattern, current)) return false;
-  await ignoreListItem.setValue([...current, pattern]);
+  if (isIgnored(trimmed, current)) return false;
+  await ignoreListItem.setValue([...current, trimmed]);
   return true;
 };
 


### PR DESCRIPTION
## 概要
- アラートバーに除外登録用の 3 点メニューを追加
- repository / owner 単位の除外登録と重複抑止を実装
- 即時反映のテストを含む関連テストを追加

## テスト
- npm run lint
- npm run typecheck
- npm run build
- npm test